### PR TITLE
chore: add storybook build to prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,9 @@
 
 # Plop Templates
 .plop-templates/*
+
+# Storybook build
+storybook-static/*
+
+# Jest coverage
+.jest-coverage/*


### PR DESCRIPTION
## Description of the change

All Netlify setup was done through the Netlify admin. This just includes a small code change to prettierignore so the storybook build files are ignored.

Closes https://github.com/Localitos/pluto/issues/10

## Testing the change

- [ ] Visit the deploy preview in the comments below.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Linear has a link to this pull request
