### PR TITLE
[TREX-7] chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Localitos/frontend

--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,8 @@
     "*.lock",
     "cspell.json",
     ".gitignore",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "CODEOWNERS"
   ],
   "overrides": [
     {


### PR DESCRIPTION
## Description of the change

Adds a CODEOWNERS file in order to assign reviewers faster. We will add frontenders from Localyze as codeowerns by now.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Linear has a link to this pull request
