### PR TITLE
fix: Add path packages to Release action

### DIFF
--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    paths:
+      - "packages/**"
     branches:
       - main
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localyze-pluto/components",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Pluto Design System Components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localyze-pluto/eslint-config",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": ".eslintrc.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localyze-pluto/theme",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Pluto Design System Theme",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localyze-pluto/tsconfig",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "tsconfig.json",
   "files": [


### PR DESCRIPTION
## Description of the change

In order to avoid trying to publish packages in every merging to main, we added a path to `packages` in the Release Github Action. Thanks, @richbachman 🙏🏻 

Plus: We updated some package versions before publishing them to npm.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Linear has a link to this pull request
