### PR TITLE
feat(components): add text primitive component

### DIFF
--- a/.changeset/wise-spies-leave.md
+++ b/.changeset/wise-spies-leave.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Text]: The initial release of the Text component. A primitive component that can be used to create all text styles in Pluto.
+
+[Box]: Changed the as prop to be typed as `keyof JSX.IntrinsicElements`

--- a/cspell.json
+++ b/cspell.json
@@ -12,7 +12,8 @@
     "moderat",
     "npmrc",
     "rgba",
-    "testid"
+    "testid",
+    "keyof"
   ],
   "flagWords": ["hte"],
   "allowCompoundWords": true,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./primitives/Box";
+export * from "./primitives/Text";

--- a/packages/components/src/primitives/Box/BaseBox.tsx
+++ b/packages/components/src/primitives/Box/BaseBox.tsx
@@ -5,7 +5,7 @@ export interface BaseBoxProps
   extends React.HTMLAttributes<HTMLElement>,
     CSSProp {
   /** Changes which HTML tag a component renders. */
-  as?: React.ReactNode;
+  as: keyof JSX.IntrinsicElements;
   /** The contents of the container. Any valid HTML. */
   children?: React.ReactNode;
   /** Boolean to set the aria-hidden prop of the container. */

--- a/packages/components/src/primitives/Box/BaseBox.tsx
+++ b/packages/components/src/primitives/Box/BaseBox.tsx
@@ -5,7 +5,7 @@ export interface BaseBoxProps
   extends React.HTMLAttributes<HTMLElement>,
     CSSProp {
   /** Changes which HTML tag a component renders. */
-  as: keyof JSX.IntrinsicElements;
+  as?: keyof JSX.IntrinsicElements;
   /** The contents of the container. Any valid HTML. */
   children?: React.ReactNode;
   /** Boolean to set the aria-hidden prop of the container. */

--- a/packages/components/src/primitives/Text/BaseText.tsx
+++ b/packages/components/src/primitives/Text/BaseText.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+export interface BaseTextProps extends React.HTMLAttributes<HTMLElement> {
+  /** Changes which HTML tag a component renders. */
+  as?: keyof JSX.IntrinsicElements;
+  /** The contents of the container. Any valid HTML. */
+  children?: React.ReactNode;
+  /** The URL that the hyperlink points to. */
+  href?: string;
+  /** The relationship of the linked URL as space-separated link types. */
+  rel?: string;
+  /** Where to display the linked URL, as the name for a browsing context (a tab, window, or <iframe>). */
+  target?: string;
+}
+
+/** The BaseText is the basis for Text. It handles the ref forwarding and other baseline props. */
+const BaseText = React.forwardRef<HTMLSpanElement, BaseTextProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <span ref={ref} {...props}>
+        {children}
+      </span>
+    );
+  }
+);
+
+BaseText.displayName = "BaseText";
+
+export { BaseText };

--- a/packages/components/src/primitives/Text/Text.stories.tsx
+++ b/packages/components/src/primitives/Text/Text.stories.tsx
@@ -1,0 +1,48 @@
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { Text } from "./Text";
+
+export default {
+  component: Text,
+  title: "Primitives/Text",
+} as ComponentMeta<typeof Text>;
+
+const Template: ComponentStory<typeof Text> = (args) => <Text {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: "This is the text component.",
+};
+
+export const Heading = Template.bind({});
+Heading.args = {
+  as: "h2",
+  children: "This is the text component as a heading.",
+  fontWeight: "fontWeightMedium",
+  fontSize: "fontSize50",
+  lineHeight: "lineHeight60",
+};
+
+export const Paragraph = Template.bind({});
+Paragraph.args = {
+  as: "p",
+  children: "This is the text component as a paragraph.",
+};
+
+export const ErrorText = Template.bind({});
+ErrorText.args = {
+  children: "This is the text component as an error message.",
+  color: "colorTextError",
+};
+
+export const Underlined = Template.bind({});
+Underlined.args = {
+  children: "This is underlined text.",
+  textDecoration: "underline",
+};
+
+export const Uppercase = Template.bind({});
+Uppercase.args = {
+  children: "This is uppercase text.",
+  textTransform: "uppercase",
+};

--- a/packages/components/src/primitives/Text/Text.test.tsx
+++ b/packages/components/src/primitives/Text/Text.test.tsx
@@ -30,7 +30,12 @@ describe("<Text />", () => {
 
   it("should render as an anchor with an href", () => {
     render(
-      <Text as="a" href="https://localyzeapp.com">
+      <Text
+        as="a"
+        href="https://localyzeapp.com"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
         This is an anchor
       </Text>
     );
@@ -38,6 +43,14 @@ describe("<Text />", () => {
     expect(renderedText).toHaveAttribute(
       "href",
       expect.stringContaining("https://localyzeapp.com")
+    );
+    expect(renderedText).toHaveAttribute(
+      "rel",
+      expect.stringContaining("noreferrer noopener")
+    );
+    expect(renderedText).toHaveAttribute(
+      "target",
+      expect.stringContaining("_blank")
     );
   });
 });

--- a/packages/components/src/primitives/Text/Text.test.tsx
+++ b/packages/components/src/primitives/Text/Text.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Text } from "./Text";
+
+const childString = "This is a span";
+
+describe("<Text />", () => {
+  it("should render a Text as a div", () => {
+    render(<Text>{childString}</Text>);
+    const renderedText = screen.getByText(childString);
+    expect(renderedText).toBeInTheDocument();
+  });
+
+  it("should render a Text as a heading", () => {
+    render(<Text as="h2">This is a heading</Text>);
+    const renderedText = screen.getByRole("heading", { level: 2 });
+    expect(renderedText).toBeInTheDocument();
+  });
+
+  it("should render with a background color class", () => {
+    render(<Text color="colorTextLink">{childString}</Text>);
+    const renderedText = screen.getByText(childString);
+    // Using toHaveAttribute here because the Stitches classNames are dynamic. We just want part of the className.
+    // eslint-disable-next-line jest-dom/prefer-to-have-class
+    expect(renderedText).toHaveAttribute(
+      "class",
+      expect.stringContaining("color-colorTextLink")
+    );
+  });
+
+  it("should render as an anchor with an href", () => {
+    render(
+      <Text as="a" href="https://localyzeapp.com">
+        This is an anchor
+      </Text>
+    );
+    const renderedText = screen.getByRole("link");
+    expect(renderedText).toHaveAttribute(
+      "href",
+      expect.stringContaining("https://localyzeapp.com")
+    );
+  });
+});

--- a/packages/components/src/primitives/Text/Text.tsx
+++ b/packages/components/src/primitives/Text/Text.tsx
@@ -1,0 +1,111 @@
+import { styled } from "@localyze-pluto/theme";
+import { getVariants } from "../../utils/get-variants";
+import { BaseText } from "./BaseText";
+import type { BaseTextProps } from "./BaseText";
+
+export type TextProps = BaseTextProps;
+
+/** A primitive component that can be used to create all text styles in Pluto. */
+const Text = styled(BaseText, {
+  color: "$colorText",
+  fontFamily: "$moderat",
+  fontWeight: "$fontWeightRegular",
+  fontSize: "$fontSize10",
+  lineHeight: "$lineHeight10",
+  margin: "$space0",
+  padding: "$space0",
+  variants: {
+    color: {
+      colorTextStrongest: {
+        color: "$colorTextStrongest",
+      },
+      colorTextStronger: {
+        colorTextStronger: "$colorTextStronger",
+      },
+      colorText: {
+        color: "$colorText",
+      },
+      colorTextError: {
+        color: "$colorTextError",
+      },
+      colorTextWarning: {
+        color: "$colorTextWarning",
+      },
+      colorTextSuccess: {
+        color: "$colorTextSuccess",
+      },
+      colorTextInverse: {
+        color: "$colorTextInverse",
+      },
+      colorTextLink: {
+        color: "$colorTextLink",
+      },
+      colorTextLinkStrong: {
+        color: "$colorTextLinkStrong",
+      },
+      colorTextHeading: {
+        color: "$colorTextHeading",
+      },
+    },
+    cursor: {
+      notAllowed: {
+        cursor: "not-allowed",
+      },
+      pointer: {
+        cursor: "pointer",
+      },
+      wait: {
+        cursor: "wait",
+      },
+    },
+    display: {
+      block: {
+        display: "block",
+      },
+      inline: {
+        display: "inline",
+      },
+      inlineBlock: {
+        display: "inline-block",
+      },
+    },
+    lineHeight: getVariants("lineHeights", (tokenValue) => ({
+      lineHeight: tokenValue,
+    })),
+    fontFamily: getVariants("fonts", (tokenValue) => ({
+      fontFamily: tokenValue,
+    })),
+    fontSize: getVariants("fontSizes", (tokenValue) => ({
+      fontSize: tokenValue,
+    })),
+    fontWeight: getVariants("fontWeights", (tokenValue) => ({
+      fontWeight: tokenValue,
+    })),
+    textDecoration: {
+      none: {
+        textDecoration: "none",
+      },
+      underline: {
+        textDecoration: "underline",
+      },
+    },
+    textTransform: {
+      none: {
+        textTransform: "none",
+      },
+      uppercase: {
+        textTransform: "uppercase",
+      },
+      lowercase: {
+        textTransform: "lowercase",
+      },
+      capitalize: {
+        textTransform: "capitalize",
+      },
+    },
+  },
+});
+
+Text.displayName = "Text";
+
+export { Text };

--- a/packages/components/src/primitives/Text/index.ts
+++ b/packages/components/src/primitives/Text/index.ts
@@ -1,0 +1,1 @@
+export * from "./Text";


### PR DESCRIPTION
## Description of the change

![Screen Shot 2022-09-20 at 14 02 08](https://user-images.githubusercontent.com/1350081/191342593-2757aac8-7186-411b-a869-902f116f2fb3.png)

This is the first version of the Text primitive component. Text is a slimmed down version of Box that should be used to create all text styles in Pluto.

Text comes with all text related variant props, i.e: color, fontSize and lineHeight. Text also includes display variants, and cursor variants.

The variants are also responsive as they are in Box.

## Testing the change

- [ ] Fire up Storybook and verify the stories display properly
- [ ] Build something in Storybook using Text

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
