### PR TITLE
chore: remove dependabot branchs from visual regression tests action

### DIFF
--- a/.github/workflows/visual_regression_tests.yml
+++ b/.github/workflows/visual_regression_tests.yml
@@ -2,6 +2,8 @@ name: "Visual Tests"
 
 on:
   pull_request:
+    branches-ignore:
+      - "dependabot**"
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     paths:


### PR DESCRIPTION
## Description of the change

To avoid running visual regression tests with Chromatic for every new dependabot PRs, we will remove these branches from the vrt action. 

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
