### PR TITLE
fix: dependabot pattern on vrt action

### DIFF
--- a/.github/workflows/visual_regression_tests.yml
+++ b/.github/workflows/visual_regression_tests.yml
@@ -3,7 +3,7 @@ name: "Visual Tests"
 on:
   pull_request:
     branches-ignore:
-      - "dependabot**"
+      - "dependabot/**"
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     paths:


### PR DESCRIPTION
## Description of the change

This PR tries to fix the dependabot pattern we added in the visual regression tests action to remove the necessity of running this action for some branches.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
