### PR TITLE
fix(theme): added types to export and correct peerDeps

### DIFF
--- a/.changeset/pink-cups-sniff.md
+++ b/.changeset/pink-cups-sniff.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Added correct peerDependencies

--- a/.changeset/plenty-guests-drop.md
+++ b/.changeset/plenty-guests-drop.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+Exporting the correct types and added correct peerDependencies.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,11 @@
     "@xstyled/styled-components": "^3.6.0",
     "styled-components": "^5.3.6"
   },
+  "peerDependencies": {
+    "@localyze-pluto/theme": "^1.0.0",
+    "@xstyled/styled-components": "^3.6.0",
+    "styled-components": "^5.3.6"
+  },
   "devDependencies": {
     "@localyze-pluto/eslint-config": "^1.0.1",
     "@localyze-pluto/tsconfig": "^1.0.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -31,6 +31,10 @@
     "@xstyled/styled-components": "^3.6.0",
     "styled-components": "^5.3.6"
   },
+  "peerDependencies": {
+    "@xstyled/styled-components": "^3.6.0",
+    "styled-components": "^5.3.6"
+  },
   "devDependencies": {
     "@localyze-pluto/eslint-config": "^1.0.1",
     "@localyze-pluto/tsconfig": "^1.0.0",

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,8 +1,22 @@
-export {
-  createGlobalStyle,
-  Preflight,
-  ThemeProvider,
-} from "@xstyled/styled-components";
+import "styled-components";
+import "@xstyled/system";
+import { theme } from "./theme/default";
+
+type AppTheme = typeof theme;
+
+declare module "@xstyled/system" {
+  // XStyled wants an interace here.
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends AppTheme {}
+}
+
+declare module "styled-components" {
+  // XStyled wants an interace here.
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends AppTheme {}
+}
+
+export * from "@xstyled/styled-components";
 export * from "./theme/default";
 export * from "./styles/base";
 export * from "./styles/global";


### PR DESCRIPTION
## Description of the change

This PR adds the correct types to the theme package and updates the peerDependencies for both theme and components. This should fix the type autocomplete issue in the talent-web app.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
