### PR TITLE
feat(components): add heading component

### DIFF
--- a/.changeset/happy-crews-protect.md
+++ b/.changeset/happy-crews-protect.md
@@ -1,0 +1,16 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+This includes a few minor fontSize and lineHeight changes.
+
+fontSizes
+
+- Changed `fontSize80` to 48px
+- Added `fontSize90`
+
+lineHeights
+
+- Changed `lineHeight80` to 48px
+- Changed `lineHeight90` to 54px
+- Added `lineHeight100`

--- a/.changeset/warm-pigs-arrive.md
+++ b/.changeset/warm-pigs-arrive.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Heading]: Added the Heading component. It can be multiple sizes, and render as any valid heading element. Heading also includes a default bottom margin, which can be overridden to have no bottom margin.

--- a/packages/components/src/components/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/Heading/Heading.stories.tsx
@@ -1,0 +1,59 @@
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { Heading } from "./Heading";
+
+export default {
+  component: Heading,
+  title: "Components/Heading",
+} as ComponentMeta<typeof Heading>;
+
+const Template: ComponentStory<typeof Heading> = (args) => (
+  <Heading {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  children: "I'm a heading.",
+};
+
+export const Heading10 = Template.bind({});
+Heading10.args = {
+  children: "I'm a h2 element with heading10 styles.",
+  size: "heading10",
+};
+
+export const Heading20 = Template.bind({});
+Heading20.args = {
+  children: "I'm a h2 element with Heading20 styles.",
+  size: "heading20",
+};
+
+export const Heading30 = Template.bind({});
+Heading30.args = {
+  children: "I'm a h2 element with Heading30 styles.",
+  size: "heading30",
+};
+
+export const Heading40 = Template.bind({});
+Heading40.args = {
+  children: "I'm a h2 element with Heading40 styles.",
+  size: "heading40",
+};
+
+export const Heading50 = Template.bind({});
+Heading50.args = {
+  children: "I'm a h2 element with Heading50 styles.",
+  size: "heading50",
+};
+
+export const Heading60 = Template.bind({});
+Heading60.args = {
+  children: "I'm a h2 element with Heading60 styles.",
+  size: "heading60",
+};
+
+export const NoMargin = Template.bind({});
+NoMargin.args = {
+  children: "I'm a h2 element with no bottom margin.",
+  marginBottom: "space0",
+};

--- a/packages/components/src/components/Heading/Heading.test.tsx
+++ b/packages/components/src/components/Heading/Heading.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Heading } from "./Heading";
+
+const text = "This is a heading.";
+
+describe("<Heading />", () => {
+  it("should render an h2 heading", () => {
+    render(<Heading>{text}</Heading>);
+    const renderedHeading = screen.getByRole("heading", { level: 2 });
+    expect(renderedHeading).toBeInTheDocument();
+  });
+
+  it("should render an h1 heading", () => {
+    render(<Heading as="h1">{text}</Heading>);
+    const renderedHeading = screen.getByRole("heading", { level: 1 });
+    expect(renderedHeading).toBeInTheDocument();
+  });
+
+  it("should render an h3 heading", () => {
+    render(<Heading as="h3">{text}</Heading>);
+    const renderedHeading = screen.getByRole("heading", { level: 3 });
+    expect(renderedHeading).toBeInTheDocument();
+  });
+
+  it("should render an h4 heading", () => {
+    render(<Heading as="h4">{text}</Heading>);
+    const renderedHeading = screen.getByRole("heading", { level: 4 });
+    expect(renderedHeading).toBeInTheDocument();
+  });
+
+  it("should render an h5 heading", () => {
+    render(<Heading as="h5">{text}</Heading>);
+    const renderedHeading = screen.getByRole("heading", { level: 5 });
+    expect(renderedHeading).toBeInTheDocument();
+  });
+
+  it("should render an h6 heading", () => {
+    render(<Heading as="h6">{text}</Heading>);
+    const renderedHeading = screen.getByRole("heading", { level: 6 });
+    expect(renderedHeading).toBeInTheDocument();
+  });
+
+  it("should allow for global html Attributes", () => {
+    render(
+      <Heading aria-label="foo" data-testid="bar">
+        {text}
+      </Heading>
+    );
+    expect(screen.getByTestId("bar")).toBeInTheDocument();
+    expect(screen.getByLabelText("foo")).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import type { SystemProp, Theme } from "@xstyled/styled-components";
+import { Text } from "../../primitives/Text";
+
+type HeadingLevelOptions = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type HeadingMarginOptions = "space0" | "space70";
+type HeadingSizeOptions =
+  | "heading10"
+  | "heading20"
+  | "heading30"
+  | "heading40"
+  | "heading50"
+  | "heading60";
+
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  /** Sets the HTML element on render. */
+  as?: HeadingLevelOptions;
+  /** The contents of the heading. Can be text or valid text related HTML, i.e. anchor and strong elements. */
+  children: NonNullable<React.ReactNode>;
+  /** Changes the bottom margin of the heading.  */
+  marginBottom?: HeadingMarginOptions;
+  /** Changes the size of the heading. */
+  size?: HeadingSizeOptions;
+}
+
+const getHeadingStyles = (
+  size: HeadingSizeOptions
+): {
+  fontSize: SystemProp<keyof Theme["fontSizes"], Theme>;
+  lineHeight: SystemProp<keyof Theme["lineHeights"], Theme>;
+} => {
+  switch (size) {
+    case "heading10": {
+      return {
+        fontSize: "fontSize90",
+        lineHeight: "lineHeight100",
+      };
+    }
+    case "heading30": {
+      return {
+        fontSize: "fontSize70",
+        lineHeight: "lineHeight80",
+      };
+    }
+    case "heading40": {
+      return {
+        fontSize: "fontSize60",
+        lineHeight: "lineHeight70",
+      };
+    }
+    case "heading50": {
+      return {
+        fontSize: "fontSize50",
+        lineHeight: "lineHeight60",
+      };
+    }
+    case "heading60": {
+      return {
+        fontSize: "fontSize40",
+        lineHeight: "lineHeight50",
+      };
+    }
+    default: {
+      return {
+        fontSize: "fontSize80",
+        lineHeight: "lineHeight90",
+      };
+    }
+  }
+};
+
+/** A heading is text that gives hierarchical structure to a page */
+const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  (
+    { as, children, marginBottom = "space70", size = "heading20", ...props },
+    ref
+  ) => {
+    return (
+      <Text.h2
+        as={as}
+        fontFamily="fontFamilyModerat"
+        fontWeight="fontWeightBold"
+        marginBottom={marginBottom}
+        ref={ref}
+        {...getHeadingStyles(size)}
+        {...props}
+      >
+        {children}
+      </Text.h2>
+    );
+  }
+);
+
+Heading.displayName = "Heading";
+
+export { Heading };

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -1,0 +1,1 @@
+export * from "./Heading";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./components/Heading";
 export * from "./components/Paragraph";
 export * from "./primitives/Box";
 export * from "./primitives/Text";

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -77,7 +77,8 @@ Object {
     "fontSize50": "1.5rem",
     "fontSize60": "2rem",
     "fontSize70": "2.5rem",
-    "fontSize80": "3.375rem",
+    "fontSize80": "3rem",
+    "fontSize90": "3.375rem",
   },
   "fontWeights": Object {
     "fontWeightBold": "700",
@@ -120,14 +121,15 @@ Object {
   },
   "lineHeights": Object {
     "lineHeight10": "1rem",
+    "lineHeight100": "3.75rem",
     "lineHeight20": "1.125rem",
     "lineHeight30": "1.25rem",
     "lineHeight40": "1.5rem",
     "lineHeight50": "1.75rem",
     "lineHeight60": "2rem",
     "lineHeight70": "2.5rem",
-    "lineHeight80": "3.375rem",
-    "lineHeight90": "4rem",
+    "lineHeight80": "3rem",
+    "lineHeight90": "3.375rem",
   },
   "radii": Object {
     "borderRadius10": "4px",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -61,7 +61,8 @@ export const theme = {
     fontSize50: "1.5rem", // 24px
     fontSize60: "2rem", // 32px
     fontSize70: "2.5rem", // 40px
-    fontSize80: "3.375rem", // 54px
+    fontSize80: "3rem", // 48px
+    fontSize90: "3.375rem", // 54px
   },
   fontWeights: {
     fontWeightLight: "300",
@@ -80,8 +81,9 @@ export const theme = {
     lineHeight50: "1.75rem", // 28px
     lineHeight60: "2rem", // 32px
     lineHeight70: "2.5rem", // 40px
-    lineHeight80: "3.375rem", // 54px
-    lineHeight90: "4rem", // 64px
+    lineHeight80: "3rem", // 48px
+    lineHeight90: "3.375rem", // 54px
+    lineHeight100: "3.75rem", // 60px
   },
   radii: {
     borderRadius10: "4px",


### PR DESCRIPTION
## Description of the change

This adds the Heading component. It can be multiple sizes, and render as any valid heading element. Heading also includes a default bottom margin, which can be overridden to have no bottom margin.

This also updates the theme package with new fontSizes and lineHeights.

## Testing the change

- [x] Fire up Storybook and make sure the Paragraph stories work properly.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
