### PR TITLE
feat(components): add button component

### DIFF
--- a/.changeset/lucky-cows-lay.md
+++ b/.changeset/lucky-cows-lay.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Button]: Added the Button component with one variant, primary. Button also has two sizes (small and large).

--- a/.changeset/shy-games-end.md
+++ b/.changeset/shy-games-end.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+Added the `loading` custom state to the theme. This can be used to style `aria-busy` elements.

--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,10 @@
     "chromaui",
     "xstyled",
     "nums",
-    "bezier"
+    "bezier",
+    "xlarge",
+    "xsmall",
+    "unhover"
   ],
   "flagWords": ["hte"],
   "allowCompoundWords": true,

--- a/packages/components/src/components/Button/Button.stories.tsx
+++ b/packages/components/src/components/Button/Button.stories.tsx
@@ -1,0 +1,40 @@
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { Button } from "./Button";
+
+export default {
+  component: Button,
+  title: "Components/Button",
+} as ComponentMeta<typeof Button>;
+
+const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: "Primary button",
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  children: "Large primary button",
+  size: "large",
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  children: "Primary disabled button",
+  disabled: true,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  children: "Loading...",
+  loading: true,
+};
+
+export const AsLink = Template.bind({});
+AsLink.args = {
+  as: "a",
+  children: "Link button",
+  href: "#",
+};

--- a/packages/components/src/components/Button/Button.test.tsx
+++ b/packages/components/src/components/Button/Button.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import React from "react";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  describe("Render", () => {
+    it("should render a primary button", () => {
+      render(<Button variant="primary">Primary Button</Button>);
+      const renderedButton = screen.getByRole("button");
+      expect(renderedButton).toBeInTheDocument();
+    });
+
+    it("should render as an anchor", () => {
+      render(
+        <Button as="a" href="#" variant="primary">
+          Primary Button
+        </Button>
+      );
+      const renderedButton = screen.getByRole("link");
+      expect(renderedButton).toBeInTheDocument();
+    });
+
+    it("should render disabled set on HTML when disabled", () => {
+      render(
+        <Button disabled variant="primary">
+          Primary Button
+        </Button>
+      );
+      const renderedButton = screen.getByRole("button");
+      expect(renderedButton).toBeDisabled();
+    });
+
+    it("should render loading set on HTML when loading", () => {
+      render(
+        <Button loading variant="primary">
+          Primary Button
+        </Button>
+      );
+      const renderedButton = screen.getByRole("button");
+      expect(renderedButton.getAttribute("aria-busy")).toBeTruthy();
+    });
+  });
+
+  describe("Event handlers", () => {
+    it("should call the appropriate event handlers", async () => {
+      const onClickMock: jest.Mock = jest.fn();
+      const onMouseEnterMock: jest.Mock = jest.fn();
+      const onMouseLeaveMock: jest.Mock = jest.fn();
+
+      const user = userEvent.setup() as UserEvent;
+
+      render(
+        <Button
+          onClick={onClickMock}
+          onMouseEnter={onMouseEnterMock}
+          onMouseLeave={onMouseLeaveMock}
+          variant="primary"
+        >
+          button
+        </Button>
+      );
+
+      const renderedBox = screen.getByRole("button");
+      expect(renderedBox).toBeInTheDocument();
+
+      await user.click(renderedBox);
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+
+      await user.hover(renderedBox);
+      expect(onMouseEnterMock).toHaveBeenCalledTimes(1);
+
+      await user.unhover(renderedBox);
+      expect(onMouseLeaveMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import type { SystemProp, Theme } from "@xstyled/styled-components";
+import { Box } from "../../primitives/Box";
+
+type ButtonSizeOptions = "large" | "small";
+type ButtonVariantOptions = "primary";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Sets the render element of the component. Either 'a' or 'button'.*/
+  as?: "a" | "button";
+  /** Add a description comment for each prop. */
+  children?: NonNullable<React.ReactNode>;
+  /** If used as an 'a', the href is url that the link point to. */
+  href?: string;
+  /** Sets the button to be disabled. */
+  isDisabled?: boolean;
+  /** Sets the button state to loading. */
+  loading?: boolean;
+  /** Used with React Router or NextJS to set the route the anchor links to. */
+  to?: string;
+  /** Sets the size of the button. */
+  size?: ButtonSizeOptions;
+  /** Sets the variant of the button. */
+  variant: ButtonVariantOptions;
+}
+
+const getButtonVariantStyles = (
+  // Will be needed in the future.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  variant: ButtonVariantOptions
+): {
+  backgroundColor: SystemProp<keyof Theme["colors"], Theme>;
+  borderColor: SystemProp<keyof Theme["colors"], Theme>;
+} => {
+  return {
+    backgroundColor: {
+      _: "colorBackgroundPrimary",
+      hover: "colorBackgroundPrimaryStrong",
+      disabled: "colorIconWeak",
+    },
+    borderColor: {
+      _: "colorBorderPrimary",
+      hover: "colorBorderPrimary",
+      disabled: "colorIconWeak",
+    },
+  };
+};
+
+/** A button is a clickable element which communicates that users can trigger an action. */
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      children,
+      isDisabled,
+      loading,
+      size = "small",
+      variant = "primary",
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Box.button
+        appearance="none"
+        aria-busy={loading ? "true" : "false"}
+        background="none"
+        borderRadius="borderRadius20"
+        borderStyle="borderSolid"
+        borderWidth="borderWidth10"
+        color="colorTextInverse"
+        cursor={{
+          _: "default",
+          hover: "pointer",
+          disabled: "not-allowed",
+          loading: "wait",
+        }}
+        disabled={isDisabled}
+        display="inline-block"
+        fontFamily="fontFamilyModerat"
+        fontSize={size === "large" ? "fontSize30" : "fontSize10"}
+        fontWeight="fontWeightMedium"
+        lineHeight={size === "large" ? "lineHeight40" : "lineHeight10"}
+        outlineColor={{ focus: "colorBorderPrimary" }}
+        outlineOffset={{ focus: "borderWidth20" }}
+        outlineStyle={{ focus: "solid" }}
+        outlineWidth={{ focus: "borderWidth20" }}
+        paddingBottom={size === "large" ? "space40" : "space30"}
+        paddingLeft={size === "large" ? "space50" : "space40"}
+        paddingRight={size === "large" ? "space50" : "space40"}
+        paddingTop={size === "large" ? "space40" : "space30"}
+        ref={ref}
+        textDecoration="none"
+        transition="background-color 100ms ease-in, border-color 100ms ease-in"
+        {...getButtonVariantStyles(variant)}
+        {...props}
+      >
+        {children}
+      </Box.button>
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };

--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export * from "./Button";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./components/Button";
 export * from "./components/Heading";
 export * from "./components/Icon";
 export * from "./components/Paragraph";

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -216,6 +216,7 @@ Object {
     "focusWithin": "&:focus-within",
     "hover": "&:hover",
     "last": "&:last-child",
+    "loading": "&[aria-busy=\\"true\\"]",
     "motionReduce": "@media (prefers-reduced-motion: reduce)",
     "motionSafe": "@media (prefers-reduced-motion: no-preference)",
     "odd": "&:odd",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -147,6 +147,10 @@ export const theme = {
     spaceNegative180: "-6rem", // -96px
     spaceNegative190: "-6.25rem", // -100px
   },
+  states: {
+    ...defaultTheme.states,
+    loading: '&[aria-busy="true"]',
+  },
   zIndices: {
     zIndex0: 0,
     zIndex10: 10,


### PR DESCRIPTION
## Description of the change

This adds the button component. It only has one variant right now and two sizes. Stories and tests are added as well. Along with this, I added a `loading` state to our theme, so we can style `aria-busy` elements.

## Testing the change

- [ ] Fire up Storybook or check out Chromatic.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
