### PR TITLE
fix: update github PR checks action by using GITHUB_OUTPUT env file

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Load Yarn cache
         uses: actions/cache@v2
@@ -72,7 +72,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Load Yarn cache
         uses: actions/cache@v2
@@ -119,7 +119,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Load Yarn cache
         uses: actions/cache@v2
@@ -170,7 +170,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Load Yarn cache
         uses: actions/cache@v2


### PR DESCRIPTION
## Description of the change

I noticed that these three actions were stuck in the [Version Packages PR](https://github.com/Localitos/pluto/pull/101):

![image](https://user-images.githubusercontent.com/5320963/196765139-96aa3094-4ba4-4dec-8a8a-ce8a4eb59f93.png)

And when I checked the actions logs, I could see the warnings there:

![image](https://user-images.githubusercontent.com/5320963/196765455-7535f4bf-f92a-4836-ac67-10b6099b498c.png)



It's weird because the checks are green: 
![image](https://user-images.githubusercontent.com/5320963/196765401-223d6d85-bb9f-42de-955c-2792895a0fe9.png)

The link to the action: https://github.com/Localitos/pluto/actions/runs/3282843460

My attempt is to fix the warnings because I think they are impacting how the pipeline is shown in the checks list of the PR.
And to fix them, I just applied what Github mentioned [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).




## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
