### PR TITLE
fix: update theme peer dependecies version

### DIFF
--- a/.changeset/grumpy-actors-judge.md
+++ b/.changeset/grumpy-actors-judge.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+Updates react version on theme package in order to fix an issue on repos that use react 18

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^17.0.2 || ^18.2.0",
+    "react-dom": "^17.0.2 || ^18.2.0",
     "styled-components": "^5.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of the change

Updates the react peer dependencies on pluto theme package in order to fix an issue on repos that are using react 18.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
