### PR TITLE
feat(components): add sticky header and top props to table header

### DIFF
--- a/.changeset/cool-eagles-smoke.md
+++ b/.changeset/cool-eagles-smoke.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Table]: Added `stickyHeader` and `top` props so the table header rows can stick to the top of a container or page.

--- a/packages/components/src/components/Table/THead.tsx
+++ b/packages/components/src/components/Table/THead.tsx
@@ -6,9 +6,9 @@ export interface THeadProps
   /** The valid HTML contents of the table header. */
   children: NonNullable<React.ReactNode>;
   /** Makes the table head stick to the top of the window as the user scrolls a long table. */
-  stickyHeader?: boolean;
+  isSticky?: boolean;
   /** Allows manual control of the top offset, used in conjunction with `stickyHeader`. */
-  top?: number | string;
+  stickyTopOffset?: number | string;
 }
 
 /** Used to group header content in a table */
@@ -16,17 +16,17 @@ const THead = React.forwardRef<HTMLTableSectionElement, THeadProps>(
   (
     {
       children,
-      stickyHeader,
-      top = stickyHeader ? "-1px" : undefined,
+      isSticky,
+      stickyTopOffset = isSticky ? "-1px" : undefined,
       ...props
     },
     ref
   ) => {
     return (
       <Box.thead
-        position={stickyHeader ? "sticky" : undefined}
+        position={isSticky ? "sticky" : undefined}
         ref={ref}
-        top={top}
+        top={stickyTopOffset}
         {...props}
       >
         {children}

--- a/packages/components/src/components/Table/THead.tsx
+++ b/packages/components/src/components/Table/THead.tsx
@@ -5,8 +5,6 @@ export interface THeadProps
   extends Omit<React.TableHTMLAttributes<HTMLTableSectionElement>, "color"> {
   /** The valid HTML contents of the table header. */
   children: NonNullable<React.ReactNode>;
-  /** Allows manual control of the left offset, used in conjunction with `stickyHeader`. */
-  left?: number | string;
   /** Makes the table head stick to the top of the window as the user scrolls a long table. */
   stickyHeader?: boolean;
   /** Allows manual control of the top offset, used in conjunction with `stickyHeader`. */
@@ -19,7 +17,6 @@ const THead = React.forwardRef<HTMLTableSectionElement, THeadProps>(
     {
       children,
       stickyHeader,
-      left = stickyHeader ? "-1px" : undefined,
       top = stickyHeader ? "-1px" : undefined,
       ...props
     },
@@ -27,7 +24,6 @@ const THead = React.forwardRef<HTMLTableSectionElement, THeadProps>(
   ) => {
     return (
       <Box.thead
-        left={left}
         position={stickyHeader ? "sticky" : undefined}
         ref={ref}
         top={top}

--- a/packages/components/src/components/Table/THead.tsx
+++ b/packages/components/src/components/Table/THead.tsx
@@ -5,13 +5,34 @@ export interface THeadProps
   extends Omit<React.TableHTMLAttributes<HTMLTableSectionElement>, "color"> {
   /** The valid HTML contents of the table header. */
   children: NonNullable<React.ReactNode>;
+  /** Allows manual control of the left offset, used in conjunction with `stickyHeader`. */
+  left?: number | string;
+  /** Makes the table head stick to the top of the window as the user scrolls a long table. */
+  stickyHeader?: boolean;
+  /** Allows manual control of the top offset, used in conjunction with `stickyHeader`. */
+  top?: number | string;
 }
 
 /** Used to group header content in a table */
 const THead = React.forwardRef<HTMLTableSectionElement, THeadProps>(
-  ({ children, ...props }, ref) => {
+  (
+    {
+      children,
+      stickyHeader,
+      left = stickyHeader ? "-1px" : undefined,
+      top = stickyHeader ? "-1px" : undefined,
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <Box.thead ref={ref} {...props}>
+      <Box.thead
+        left={left}
+        position={stickyHeader ? "sticky" : undefined}
+        ref={ref}
+        top={top}
+        {...props}
+      >
         {children}
       </Box.thead>
     );

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -11,6 +11,7 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import map from "lodash/map";
+import { Box } from "../../primitives/Box";
 import { Table, THead, TBody, Tr, Th, Td } from "./index";
 
 export default {
@@ -47,6 +48,81 @@ Default.parameters = {
     storyDescription:
       "You can use the various table elements to make up your table without having to worry about the styling.",
   },
+};
+
+export const StickyHeaders = (): JSX.Element => {
+  return (
+    <Table>
+      <THead stickyHeader>
+        <Tr>
+          <Th>Column 1</Th>
+          <Th>Column 2</Th>
+          <Th>Column 3</Th>
+        </Tr>
+        <Tr>
+          <Th>Column 1</Th>
+          <Th>Column 2</Th>
+          <Th>Column 3</Th>
+        </Tr>
+      </THead>
+      <TBody>
+        {map([...Array.from({ length: 100 }).keys()], (index) => (
+          <Tr key={index}>
+            <Td>Content</Td>
+            <Td>Content</Td>
+            <Td>Content</Td>
+          </Tr>
+        ))}
+      </TBody>
+    </Table>
+  );
+};
+
+StickyHeaders.story = {
+  name: "Sticky headers",
+};
+
+export const StickyFirstColumn = (): JSX.Element => {
+  return (
+    <Box.div h="500px" overflowX="auto" w="500px">
+      <Table>
+        <THead stickyHeader>
+          <Tr>
+            <Th stickyColumn>Column 1</Th>
+            <Th>Column 2</Th>
+            <Th>Column 3</Th>
+            <Th>Column 4</Th>
+            <Th>Column 5</Th>
+            <Th>Column 6</Th>
+            <Th>Column 7</Th>
+            <Th>Column 8</Th>
+            <Th>Column 9</Th>
+            <Th>Column 10</Th>
+          </Tr>
+        </THead>
+        <TBody>
+          {map([...Array.from({ length: 100 }).keys()], (index) => (
+            <Tr key={index}>
+              <Th stickyColumn>Content</Th>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+    </Box.div>
+  );
+};
+
+StickyFirstColumn.story = {
+  name: "Sticky first column",
 };
 
 export const ReactTable = (): JSX.Element => {

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -11,7 +11,6 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import map from "lodash/map";
-import { Box } from "../../primitives/Box";
 import { Table, THead, TBody, Tr, Th, Td } from "./index";
 
 export default {
@@ -80,49 +79,6 @@ export const StickyHeaders = (): JSX.Element => {
 
 StickyHeaders.story = {
   name: "Sticky headers",
-};
-
-export const StickyFirstColumn = (): JSX.Element => {
-  return (
-    <Box.div h="500px" overflowX="auto" w="500px">
-      <Table>
-        <THead stickyHeader>
-          <Tr>
-            <Th stickyColumn>Column 1</Th>
-            <Th>Column 2</Th>
-            <Th>Column 3</Th>
-            <Th>Column 4</Th>
-            <Th>Column 5</Th>
-            <Th>Column 6</Th>
-            <Th>Column 7</Th>
-            <Th>Column 8</Th>
-            <Th>Column 9</Th>
-            <Th>Column 10</Th>
-          </Tr>
-        </THead>
-        <TBody>
-          {map([...Array.from({ length: 100 }).keys()], (index) => (
-            <Tr key={index}>
-              <Th stickyColumn>Content</Th>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-              <Td>Content</Td>
-            </Tr>
-          ))}
-        </TBody>
-      </Table>
-    </Box.div>
-  );
-};
-
-StickyFirstColumn.story = {
-  name: "Sticky first column",
 };
 
 export const ReactTable = (): JSX.Element => {

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -52,7 +52,7 @@ Default.parameters = {
 export const StickyHeaders = (): JSX.Element => {
   return (
     <Table>
-      <THead stickyHeader>
+      <THead isSticky>
         <Tr>
           <Th>Column 1</Th>
           <Th>Column 2</Th>

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -11,6 +11,7 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import map from "lodash/map";
+import { Box } from "../../primitives/Box";
 import { Table, THead, TBody, Tr, Th, Td } from "./index";
 
 export default {
@@ -51,29 +52,31 @@ Default.parameters = {
 
 export const StickyHeaders = (): JSX.Element => {
   return (
-    <Table>
-      <THead isSticky>
-        <Tr>
-          <Th>Column 1</Th>
-          <Th>Column 2</Th>
-          <Th>Column 3</Th>
-        </Tr>
-        <Tr>
-          <Th>Column 1</Th>
-          <Th>Column 2</Th>
-          <Th>Column 3</Th>
-        </Tr>
-      </THead>
-      <TBody>
-        {map([...Array.from({ length: 100 }).keys()], (index) => (
-          <Tr key={index}>
-            <Td>Content</Td>
-            <Td>Content</Td>
-            <Td>Content</Td>
+    <Box.div h="500px">
+      <Table>
+        <THead isSticky>
+          <Tr>
+            <Th>Column 1</Th>
+            <Th>Column 2</Th>
+            <Th>Column 3</Th>
           </Tr>
-        ))}
-      </TBody>
-    </Table>
+          <Tr>
+            <Th>Column 1</Th>
+            <Th>Column 2</Th>
+            <Th>Column 3</Th>
+          </Tr>
+        </THead>
+        <TBody>
+          {map([...Array.from({ length: 100 }).keys()], (index) => (
+            <Tr key={index}>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+    </Box.div>
   );
 };
 

--- a/packages/components/src/components/Table/Th.tsx
+++ b/packages/components/src/components/Table/Th.tsx
@@ -7,36 +7,15 @@ export interface ThProps
   children?: React.ReactNode;
   /** Used to make a cell span over multiple columns. */
   colSpan?: number;
-  /** Allows manual control of the left offset, used in conjunction with `stickyColumn`. */
-  left?: number | string;
   /** Used to make a cell span over multiple rows. */
   rowSpan?: number;
-  /** Makes the left table column stick to the left of the window as the user scrolls a wide table. */
-  stickyColumn?: boolean;
 }
 
 /** A header cell in the table, use within a <THead>. */
 const Th = React.forwardRef<HTMLTableCellElement, ThProps>(
-  (
-    {
-      children,
-      colSpan,
-      stickyColumn,
-      left = stickyColumn ? "-1px" : undefined,
-      rowSpan,
-      ...props
-    },
-    ref
-  ) => {
+  ({ children, colSpan, rowSpan, ...props }, ref) => {
     return (
-      <Box.th
-        colSpan={colSpan}
-        left={left}
-        position={stickyColumn ? "sticky" : undefined}
-        ref={ref}
-        rowSpan={rowSpan}
-        {...props}
-      >
+      <Box.th colSpan={colSpan} ref={ref} rowSpan={rowSpan} {...props}>
         {children}
       </Box.th>
     );

--- a/packages/components/src/components/Table/Th.tsx
+++ b/packages/components/src/components/Table/Th.tsx
@@ -7,15 +7,36 @@ export interface ThProps
   children?: React.ReactNode;
   /** Used to make a cell span over multiple columns. */
   colSpan?: number;
+  /** Allows manual control of the left offset, used in conjunction with `stickyColumn`. */
+  left?: number | string;
   /** Used to make a cell span over multiple rows. */
   rowSpan?: number;
+  /** Makes the left table column stick to the left of the window as the user scrolls a wide table. */
+  stickyColumn?: boolean;
 }
 
 /** A header cell in the table, use within a <THead>. */
 const Th = React.forwardRef<HTMLTableCellElement, ThProps>(
-  ({ children, colSpan, rowSpan, ...props }, ref) => {
+  (
+    {
+      children,
+      colSpan,
+      stickyColumn,
+      left = stickyColumn ? "-1px" : undefined,
+      rowSpan,
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <Box.th colSpan={colSpan} ref={ref} rowSpan={rowSpan} {...props}>
+      <Box.th
+        colSpan={colSpan}
+        left={left}
+        position={stickyColumn ? "sticky" : undefined}
+        ref={ref}
+        rowSpan={rowSpan}
+        {...props}
+      >
         {children}
       </Box.th>
     );


### PR DESCRIPTION
## Description of the change

Adding a `stickyHeader` and `top` prop to the Table Header so they can be sticky to the top of a container or page.

## Testing the change

- [ ] Check out the new story for sticky headers.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
