### PR TITLE
feat(components): allow breakpoints in heading size

### DIFF
--- a/.changeset/fair-bobcats-repeat.md
+++ b/.changeset/fair-bobcats-repeat.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Allow breakpoints in Heading size

--- a/packages/components/src/components/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/Heading/Heading.stories.tsx
@@ -52,6 +52,13 @@ Heading60.args = {
   size: "heading60",
 };
 
+export const WithBreakpoints = Template.bind({});
+WithBreakpoints.args = {
+  children: "I'm a h2 element rendered with different sizes.",
+  marginBottom: "space0",
+  size: { _: "heading60", md: "heading10" },
+};
+
 export const NoMargin = Template.bind({});
 NoMargin.args = {
   children: "I'm a h2 element with no bottom margin.",


### PR DESCRIPTION
## Description of the change

This PR allows breakpoints in `Heading`'s size prop.

## Testing the change
- Run storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.


https://user-images.githubusercontent.com/1165437/198074550-f249b7e5-756e-49ef-bcfa-5da023419e81.mp4

