### PR TITLE
feat(components): add input leading and trailing icons

### DIFF
--- a/.changeset/large-baboons-dress.md
+++ b/.changeset/large-baboons-dress.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Input]: Adds the `leadingIcon` and `trailingIcon` props to Input. These will render an icon on either the left or right side of the Input.

--- a/packages/components/src/components/Input/Input.stories.tsx
+++ b/packages/components/src/components/Input/Input.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Components/Input",
 } as ComponentMeta<typeof Input>;
 
-export const Default: React.FC = () => {
+export const Default = (): JSX.Element => {
   const inputID = useUID();
   const helpTextID = useUID();
   return (
@@ -22,7 +22,7 @@ export const Default: React.FC = () => {
   );
 };
 
-export const Large: React.FC = () => {
+export const Large = (): JSX.Element => {
   const inputID = useUID();
   return (
     <>
@@ -38,7 +38,7 @@ export const Large: React.FC = () => {
   );
 };
 
-export const Placeholder: React.FC = () => {
+export const Placeholder = (): JSX.Element => {
   const inputID = useUID();
   return (
     <>
@@ -53,7 +53,7 @@ export const Placeholder: React.FC = () => {
   );
 };
 
-export const Required: React.FC = () => {
+export const Required = (): JSX.Element => {
   const inputID = useUID();
   return (
     <>
@@ -71,7 +71,7 @@ export const Required: React.FC = () => {
   );
 };
 
-export const ReadOnly: React.FC = () => {
+export const ReadOnly = (): JSX.Element => {
   const inputID = useUID();
   return (
     <>
@@ -87,7 +87,7 @@ export const ReadOnly: React.FC = () => {
   );
 };
 
-export const Disabled: React.FC = () => {
+export const Disabled = (): JSX.Element => {
   const inputID = useUID();
   return (
     <>
@@ -103,7 +103,7 @@ export const Disabled: React.FC = () => {
   );
 };
 
-export const Error: React.FC = () => {
+export const Error = (): JSX.Element => {
   const inputID = useUID();
   const helpTextID = useUID();
   return (
@@ -124,14 +124,14 @@ export const Error: React.FC = () => {
   );
 };
 
-export const Hidden: React.FC = () => {
+export const Hidden = (): JSX.Element => {
   const inputID = useUID();
   return (
     <Input id={inputID} name="input-hidden" type="hidden" value="Hidden text" />
   );
 };
 
-export const Number: React.FC = () => {
+export const Number = (): JSX.Element => {
   const inputID = useUID();
   return (
     <>
@@ -141,7 +141,7 @@ export const Number: React.FC = () => {
   );
 };
 
-export const NumberError: React.FC = () => {
+export const NumberError = (): JSX.Element => {
   const inputID = useUID();
   const helpTextID = useUID();
   return (
@@ -157,6 +157,119 @@ export const NumberError: React.FC = () => {
       <HelpText hasError id={helpTextID}>
         Number type inputs should only contain numbers.
       </HelpText>
+    </>
+  );
+};
+
+export const LeadingIcon = (): JSX.Element => {
+  const inputID = useUID();
+  const helpTextID = useUID();
+  return (
+    <>
+      <Label htmlFor={inputID}>Text Input</Label>
+      <Input
+        id={inputID}
+        leadingIcon="InformationCircleIcon"
+        name="input"
+        type="text"
+        value="Text input"
+      />
+      <HelpText id={helpTextID}>Please enter some text.</HelpText>
+    </>
+  );
+};
+
+export const TrailingIcon = (): JSX.Element => {
+  const inputID = useUID();
+  const helpTextID = useUID();
+  return (
+    <>
+      <Label htmlFor={inputID}>Text Input</Label>
+      <Input
+        id={inputID}
+        name="input"
+        trailingIcon="MagnifyingGlassIcon"
+        type="text"
+        value="Text input"
+      />
+      <HelpText id={helpTextID}>Please enter some text.</HelpText>
+    </>
+  );
+};
+
+export const LeadingIconAndTrailingIcon = (): JSX.Element => {
+  const inputID = useUID();
+  const helpTextID = useUID();
+  return (
+    <>
+      <Label htmlFor={inputID}>Text Input</Label>
+      <Input
+        id={inputID}
+        leadingIcon="InformationCircleIcon"
+        name="input"
+        trailingIcon="MagnifyingGlassIcon"
+        type="text"
+        value="Text input"
+      />
+      <HelpText id={helpTextID}>Please enter some text.</HelpText>
+    </>
+  );
+};
+
+export const LargeLeadingIcon = (): JSX.Element => {
+  const inputID = useUID();
+  const helpTextID = useUID();
+  return (
+    <>
+      <Label htmlFor={inputID}>Text Input</Label>
+      <Input
+        id={inputID}
+        leadingIcon="InformationCircleIcon"
+        name="input"
+        size="large"
+        type="text"
+        value="Text input"
+      />
+      <HelpText id={helpTextID}>Please enter some text.</HelpText>
+    </>
+  );
+};
+
+export const LargeTrailingIcon = (): JSX.Element => {
+  const inputID = useUID();
+  const helpTextID = useUID();
+  return (
+    <>
+      <Label htmlFor={inputID}>Text Input</Label>
+      <Input
+        id={inputID}
+        name="input"
+        size="large"
+        trailingIcon="MagnifyingGlassIcon"
+        type="text"
+        value="Text input"
+      />
+      <HelpText id={helpTextID}>Please enter some text.</HelpText>
+    </>
+  );
+};
+
+export const LargeLeadingIconAndTrailingIcon = (): JSX.Element => {
+  const inputID = useUID();
+  const helpTextID = useUID();
+  return (
+    <>
+      <Label htmlFor={inputID}>Text Input</Label>
+      <Input
+        id={inputID}
+        leadingIcon="InformationCircleIcon"
+        name="input"
+        size="large"
+        trailingIcon="MagnifyingGlassIcon"
+        type="text"
+        value="Text input"
+      />
+      <HelpText id={helpTextID}>Please enter some text.</HelpText>
     </>
   );
 };

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import * as HeroOutlineIcons from "@heroicons/react/24/outline";
 import { InputBox } from "../InputBox";
 import { Box } from "../../primitives/Box";
+import { Icon } from "../Icon";
 
 export type InputTypes =
   | "date"
@@ -20,6 +22,8 @@ export interface InputTypeProps {
   pattern?: string;
 }
 
+type IconNames = keyof typeof HeroOutlineIcons;
+
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "color" | "size"> {
   disabled?: boolean;
@@ -27,6 +31,10 @@ export interface InputProps
   hasError?: boolean;
   /** The `id` of the input. */
   id?: string;
+  /** Icon to be added on the left of the input. */
+  leadingIcon?: IconNames;
+  /** Icon to be added on the right of the input. */
+  trailingIcon?: IconNames;
   /** The `name` of the input. */
   name?: string;
   /** The text to be used for the input placeholder. */
@@ -43,6 +51,28 @@ export interface InputProps
   size?: "large" | "small";
 }
 
+const getInputIcon = (
+  iconName: IconNames,
+  size?: "large" | "small",
+  isLeadingIcon?: boolean,
+  isTrailingIcon?: boolean
+) => {
+  return (
+    <Box.div
+      display="inline-flex"
+      marginLeft={isLeadingIcon ? "space40" : undefined}
+      marginRight={isTrailingIcon ? "space40" : undefined}
+    >
+      <Icon
+        color="colorIconStrong"
+        decorative
+        icon={iconName}
+        size={size === "large" ? "sizeIcon30" : "sizeIcon20"}
+      />
+    </Box.div>
+  );
+};
+
 /** An input is a form element that lets users enter one of various types of text on a single line. */
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
@@ -54,7 +84,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       placeholder,
       readOnly,
       required,
+      leadingIcon,
       size = "small",
+      trailingIcon,
       type,
       value,
       ...props
@@ -71,6 +103,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         readOnly={readOnly}
         type={type}
       >
+        {leadingIcon && getInputIcon(leadingIcon, size, true)}
         <Box.input
           appearance="none"
           aria-invalid={hasError}
@@ -110,6 +143,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           value={value}
           {...props}
         />
+        {trailingIcon && getInputIcon(trailingIcon, size, undefined, true)}
       </InputBox>
     );
   }

--- a/packages/components/src/components/InputBox/InputBox.tsx
+++ b/packages/components/src/components/InputBox/InputBox.tsx
@@ -76,6 +76,7 @@ const InputBox = React.forwardRef<HTMLDivElement, InputBoxProps>(
   ({ children, disabled, hasError, readOnly, type, ...props }, ref) => {
     return (
       <Box.div
+        alignItems="center"
         borderRadius="borderRadius20"
         borderStyle="borderSolid"
         cursor={disabled ? "not-allowed" : "auto"}
@@ -83,6 +84,7 @@ const InputBox = React.forwardRef<HTMLDivElement, InputBoxProps>(
         data-has-error={hasError}
         data-hidden={type === "hidden" ? true : null}
         data-read-only={readOnly}
+        display="flex"
         outlineColor={{ focusWithin: "colorBorderPrimary" }}
         outlineStyle={{ focusWithin: "solid" }}
         outlineWidth={{ focusWithin: "borderWidth20" }}


### PR DESCRIPTION
## Description of the change

Adds the leading icon and trailing icon props to input.

![Screen Shot 2022-10-28 at 14 13 36](https://user-images.githubusercontent.com/1350081/198714474-7eafbfb2-91b8-442d-9bbd-e6e2c5552966.png)

## Testing the change

- [ ] Run storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
