### PR TITLE
feat(components): add search input component

### DIFF
--- a/.changeset/mighty-melons-breathe.md
+++ b/.changeset/mighty-melons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Search]: Added the Search component, which is an Input with the type set to `search`. This also comes with the accessible hidden label.

--- a/packages/components/src/components/Search/Search.stories.tsx
+++ b/packages/components/src/components/Search/Search.stories.tsx
@@ -1,0 +1,21 @@
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { Search } from "./Search";
+
+export default {
+  component: Search,
+  title: "Components/Search",
+} as ComponentMeta<typeof Search>;
+
+const Template: ComponentStory<typeof Search> = (args) => <Search {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  placeholder: "Search...",
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  placeholder: "Search...",
+  size: "large",
+};

--- a/packages/components/src/components/Search/Search.test.tsx
+++ b/packages/components/src/components/Search/Search.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Search } from "./Search";
+
+describe("<Search />", () => {
+  const initialProps = {
+    id: "input",
+    name: "cool",
+    value: "value",
+    required: true,
+    disabled: true,
+    readOnly: true,
+    hasError: true,
+    placeholder: "Search",
+  };
+
+  render(<Search {...initialProps} />);
+
+  const SearchElement = screen.getByPlaceholderText(initialProps.placeholder);
+
+  it("renders correctly", () => {
+    expect(SearchElement).toBeInTheDocument();
+  });
+
+  it("should render a required search", () => {
+    expect(SearchElement).toHaveAttribute("required", "");
+  });
+
+  it("should render a disabled search", () => {
+    expect(SearchElement).toHaveAttribute("disabled", "");
+  });
+
+  it("should render a readonly search", () => {
+    expect(SearchElement).toHaveAttribute("aria-readonly", "true");
+    expect(SearchElement).toHaveAttribute("readonly", "");
+  });
+
+  it("should render a search value", () => {
+    expect(SearchElement).toHaveValue("value");
+  });
+
+  it("should render a search id", () => {
+    expect(SearchElement).toHaveAttribute("id", "input");
+  });
+
+  it("should render a search name", () => {
+    expect(SearchElement).toHaveAttribute("name", "cool");
+  });
+
+  it("should render a search type", () => {
+    expect(SearchElement).toHaveAttribute("type", "search");
+  });
+
+  it("should render a search placeholder", () => {
+    expect(SearchElement).toHaveAttribute("placeholder", "Search");
+  });
+});

--- a/packages/components/src/components/Search/Search.test.tsx
+++ b/packages/components/src/components/Search/Search.test.tsx
@@ -22,19 +22,6 @@ describe("<Search />", () => {
     expect(SearchElement).toBeInTheDocument();
   });
 
-  it("should render a required search", () => {
-    expect(SearchElement).toHaveAttribute("required", "");
-  });
-
-  it("should render a disabled search", () => {
-    expect(SearchElement).toHaveAttribute("disabled", "");
-  });
-
-  it("should render a readonly search", () => {
-    expect(SearchElement).toHaveAttribute("aria-readonly", "true");
-    expect(SearchElement).toHaveAttribute("readonly", "");
-  });
-
   it("should render a search value", () => {
     expect(SearchElement).toHaveValue("value");
   });

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -5,7 +5,16 @@ import { Input } from "../Input";
 import type { InputProps } from "../Input";
 import { Label } from "../Label";
 
-type SearchProps = Omit<InputProps, "type">;
+type SearchProps = Omit<
+  InputProps,
+  | "disabled"
+  | "hasError"
+  | "leadingIcon"
+  | "readOnly"
+  | "required"
+  | "trailingIcon"
+  | "type"
+>;
 
 /** The Search component is a text field that allows a user to enter search queries. */
 const Search = React.forwardRef<HTMLInputElement, SearchProps>(

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useUID } from "react-uid";
+import { Box } from "../../primitives/Box";
+import { Input } from "../Input";
+import type { InputProps } from "../Input";
+import { Label } from "../Label";
+
+type SearchProps = Omit<InputProps, "type">;
+
+/** The Search component is a text field that allows a user to enter search queries. */
+const Search = React.forwardRef<HTMLInputElement, SearchProps>(
+  ({ ...props }, ref) => {
+    const seachInputId = useUID();
+    return (
+      <>
+        {/* Todo: Replace with VisuallyHidden component once its built. */}
+        <Box.span
+          border="none"
+          h="1px"
+          margin="spaceNegative10"
+          overflow="hidden"
+          padding="space0"
+          position="absolute"
+          // Looks like xStyled didn't include a clip css property.
+          style={{
+            clip: "rect(0 0 0 0)",
+          }}
+          textTransform="none"
+          w="1px"
+          whiteSpace="nowrap"
+        >
+          <Label htmlFor={seachInputId}>Search</Label>
+        </Box.span>
+        <Input
+          id={seachInputId}
+          leadingIcon="MagnifyingGlassIcon"
+          ref={ref}
+          type="search"
+          {...props}
+        />
+      </>
+    );
+  }
+);
+
+Search.displayName = "Search";
+
+export { Search };

--- a/packages/components/src/components/Search/index.ts
+++ b/packages/components/src/components/Search/index.ts
@@ -1,0 +1,1 @@
+export * from "./Search";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./components/Anchor";
 export * from "./components/Badge";
+export * from "./components/Checkbox";
 export * from "./components/List";
 export * from "./components/Button";
 export * from "./components/Callout";
@@ -12,7 +13,7 @@ export * from "./components/InputBox";
 export * from "./components/Label";
 export * from "./components/Paragraph";
 export * from "./components/RichText";
+export * from "./components/Search";
 export * from "./components/Table";
-export * from "./components/Checkbox";
 export * from "./primitives/Box";
 export * from "./primitives/Text";


### PR DESCRIPTION
## Description of the change

This adds the Search component, which is an Input with the type set to `search.

![Screen Shot 2022-10-31 at 13 17 19](https://user-images.githubusercontent.com/1350081/199080545-445f1282-9ac4-4fa1-9833-df9a9602ac94.png)

## Testing the change

- [ ] Check out storybook.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
