### PR TITLE
feat(components): add full width prop to button

### DIFF
--- a/.changeset/big-scissors-live.md
+++ b/.changeset/big-scissors-live.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Allow buttons to have full width

--- a/packages/components/src/components/Button/Button.stories.tsx
+++ b/packages/components/src/components/Button/Button.stories.tsx
@@ -55,6 +55,13 @@ AsLink.args = {
   href: "#",
 };
 
+export const FullWidth = Template.bind({});
+FullWidth.args = {
+  children: "Full width button",
+  fullWidth: true,
+  leadingIcon: "ArrowTopRightOnSquareIcon",
+};
+
 export const WithLeadingIcon = Template.bind({});
 WithLeadingIcon.args = {
   children: "Small primary button",

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -31,6 +31,8 @@ export interface ButtonProps
   size?: ButtonSizeOptions;
   /** Sets the variant of the button. */
   variant: ButtonVariantOptions;
+  /** True to have a full width button, false otherwise. */
+  fullWidth?: boolean;
 }
 
 const getButtonVariantStyles = (
@@ -116,6 +118,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loading,
       leadingIcon,
       trailingIcon,
+      fullWidth,
       size = "small",
       variant = "primary",
       ...props
@@ -152,6 +155,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           fontSize={size === "large" ? "fontSize30" : "fontSize20"}
           fontWeight="fontWeightMedium"
           gap="space30"
+          justifyContent="center"
           lineHeight={size === "large" ? "lineHeight40" : "lineHeight30"}
           paddingBottom={size === "large" ? "space40" : "space30"}
           paddingLeft={size === "large" ? "space50" : "space40"}
@@ -160,6 +164,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           ref={ref}
           textDecoration="none"
           transition="background-color 100ms ease-in, border-color 100ms ease-in"
+          w={fullWidth ? "100%" : "auto"}
           {...getButtonVariantStyles(variant)}
           {...props}
         >


### PR DESCRIPTION
## Description of the change
- Add `fullWidth` prop to buttons

## Testing the change
- Run storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.

![image](https://user-images.githubusercontent.com/1165437/199278486-03fecf43-b1d9-4d5e-8542-41858676c054.png)

