### PR TITLE
feat(components): add getAvatarColor function to Avatar

### DIFF
--- a/.changeset/eleven-ads-check.md
+++ b/.changeset/eleven-ads-check.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Avatar] Add `getAvatarColor` function that generates a random background color. Styles of the default Avatar have also changed.

--- a/.changeset/strange-beans-juggle.md
+++ b/.changeset/strange-beans-juggle.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/design-tokens": patch
+---
+
+Added design tokens for new Avatar background colors.

--- a/.changeset/tall-eagles-beg.md
+++ b/.changeset/tall-eagles-beg.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+Added theme colors for new Avatar background colors.

--- a/packages/components/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/components/src/components/Avatar/Avatar.stories.tsx
@@ -3,6 +3,8 @@ import map from "lodash/map";
 import React from "react";
 import { Box } from "../../primitives/Box";
 import { Avatar, AvatarSizeOptions } from "./Avatar";
+import { getAvatarColor } from "./getAvatarColor";
+import type { AvatarColorOptions } from "./Avatar";
 
 export default {
   component: Avatar,
@@ -40,4 +42,82 @@ export const WithName = Template.bind({});
 WithName.args = {
   ...defaultArgs,
   showName: true,
+};
+
+export const InitialsAndBackgroundColors: ComponentStory<
+  typeof Avatar
+> = () => {
+  return (
+    <Box.div display="flex" flexDirection="column" gap="space40">
+      <Box.div display="flex" flexDirection="row" gap="space40">
+        <Avatar color="blue" name="Olivia Long" showName size="xsmall" />
+        <Avatar color="blue" name="Olivia Joseph" showName size="small" />
+        <Avatar color="blue" name="Jean Knight" showName size="medium" />
+        <Avatar color="blue" name="Betty Long" showName size="large" />
+      </Box.div>
+      <Box.div display="flex" flexDirection="row" gap="space40">
+        <Avatar color="green" name="Olivia Long" showName size="xsmall" />
+        <Avatar color="green" name="Olivia Joseph" showName size="small" />
+        <Avatar color="green" name="Jean Knight" showName size="medium" />
+        <Avatar color="green" name="Betty Long" showName size="large" />
+      </Box.div>
+      <Box.div display="flex" flexDirection="row" gap="space40">
+        <Avatar color="light blue" name="Olivia Long" showName size="xsmall" />
+        <Avatar color="light blue" name="Olivia Joseph" showName size="small" />
+        <Avatar color="light blue" name="Jean Knight" showName size="medium" />
+        <Avatar color="light blue" name="Betty Long" showName size="large" />
+      </Box.div>
+      <Box.div display="flex" flexDirection="row" gap="space40">
+        <Avatar color="orange" name="Olivia Long" showName size="xsmall" />
+        <Avatar color="orange" name="Olivia Joseph" showName size="small" />
+        <Avatar color="orange" name="Jean Knight" showName size="medium" />
+        <Avatar color="orange" name="Betty Long" showName size="large" />
+      </Box.div>
+      <Box.div display="flex" flexDirection="row" gap="space40">
+        <Avatar color="pink" name="Olivia Long" showName size="xsmall" />
+        <Avatar color="pink" name="Olivia Joseph" showName size="small" />
+        <Avatar color="pink" name="Jean Knight" showName size="medium" />
+        <Avatar color="pink" name="Betty Long" showName size="large" />
+      </Box.div>
+      <Box.div display="flex" flexDirection="row" gap="space40">
+        <Avatar color="yellow" name="Olivia Long" showName size="xsmall" />
+        <Avatar color="yellow" name="Olivia Joseph" showName size="small" />
+        <Avatar color="yellow" name="Jean Knight" showName size="medium" />
+        <Avatar color="yellow" name="Betty Long" showName size="large" />
+      </Box.div>
+    </Box.div>
+  );
+};
+
+export const InitialsAndRandomBackgroundColor: ComponentStory<
+  typeof Avatar
+> = () => {
+  return (
+    <Box.div display="flex" flexDirection="row" gap="space40">
+      <Avatar
+        color={getAvatarColor("Olivia Long") as AvatarColorOptions}
+        name="Olivia Long"
+        showName
+        size="xsmall"
+      />
+      <Avatar
+        color={getAvatarColor("Olivia Joseph") as AvatarColorOptions}
+        name="Olivia Joseph"
+        showName
+        size="small"
+      />
+      <Avatar
+        color={getAvatarColor("Jean Knight") as AvatarColorOptions}
+        name="Jean Knight"
+        showName
+        size="medium"
+      />
+      <Avatar
+        color={getAvatarColor("Betty Long") as AvatarColorOptions}
+        name="Betty Long"
+        showName
+        size="large"
+      />
+    </Box.div>
+  );
 };

--- a/packages/components/src/components/Avatar/Avatar.tsx
+++ b/packages/components/src/components/Avatar/Avatar.tsx
@@ -6,9 +6,19 @@ import { useGetImageOrientation } from "./useGetImageOrientation";
 import { Orientation } from "./getImageOrientation";
 import { getInitials } from "./getInitials";
 
+export type AvatarColorOptions =
+  | "blue"
+  | "green"
+  | "light blue"
+  | "orange"
+  | "pink"
+  | "yellow";
+
 export type AvatarSizeOptions = "large" | "medium" | "small" | "xsmall";
 
 export type AvatarProps = {
+  /** The color used for the avatar background. */
+  color?: AvatarColorOptions;
   /** The name of the entity being represented. */
   name: string;
   /** The image source to be used for the avatar. */
@@ -124,9 +134,48 @@ const getImageSizes = (
   return { h: "auto", w };
 };
 
+const getAvatarColorStyles = (
+  color: AvatarColorOptions
+): {
+  backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
+} => {
+  switch (color) {
+    case "green": {
+      return {
+        backgroundColor: "colorAvatarBackgroundGreen",
+      };
+    }
+    case "light blue": {
+      return {
+        backgroundColor: "colorAvatarBackgroundLightBlue",
+      };
+    }
+    case "orange": {
+      return {
+        backgroundColor: "colorAvatarBackgroundOrange",
+      };
+    }
+    case "pink": {
+      return {
+        backgroundColor: "colorAvatarBackgroundPink",
+      };
+    }
+    case "yellow": {
+      return {
+        backgroundColor: "colorAvatarBackgroundYellow",
+      };
+    }
+    default: {
+      return {
+        backgroundColor: "colorAvatarBackgroundBlue",
+      };
+    }
+  }
+};
+
 /** An avatar is an element that uses text or images to represent users visually. */
 const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
-  ({ src, name, showName, size = "medium", ...props }, ref) => {
+  ({ color = "blue", src, name, showName, size = "medium", ...props }, ref) => {
     const { orientation, hasError } = useGetImageOrientation(src);
     const shouldRenderImage = src && !hasError;
     const shouldRenderInitials = (!src && name) || (hasError && name);
@@ -138,13 +187,13 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       <Box.div alignItems="center" display="flex" gap="space30">
         <Box.div
           alignItems="center"
-          backgroundColor="colorBackgroundWeak"
           borderRadius="borderRadiusCircle"
           display="flex"
           justifyContent="center"
           overflow="hidden"
           ref={ref}
           {...ariaProps}
+          {...getAvatarColorStyles(color)}
           {...getAvatarSizes(size)}
           {...props}
         >
@@ -159,7 +208,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
           {shouldRenderInitials && (
             <Box.span
               aria-hidden={true}
-              color="colorAvatarInitials"
+              color="colorTextStronger"
               {...getInitialsSizes(size)}
             >
               {getInitials(name)}

--- a/packages/components/src/components/Avatar/getAvatarColor.test.ts
+++ b/packages/components/src/components/Avatar/getAvatarColor.test.ts
@@ -1,0 +1,10 @@
+import { getAvatarColor } from "./getAvatarColor";
+
+describe("getAvatarColor", () => {
+  it("should return a color name from a person's name", () => {
+    expect(getAvatarColor("Lisa Wang")).toBe("orange");
+    expect(getAvatarColor("Lisa")).toBe("pink");
+    expect(getAvatarColor("Jean Knight")).toBe("yellow");
+    expect(getAvatarColor("Super Long Name Example")).toBe("yellow");
+  });
+});

--- a/packages/components/src/components/Avatar/getAvatarColor.ts
+++ b/packages/components/src/components/Avatar/getAvatarColor.ts
@@ -1,0 +1,23 @@
+import type { AvatarColorOptions } from "./Avatar";
+
+const avatarColorOptions: AvatarColorOptions[] = [
+  "blue",
+  "green",
+  "light blue",
+  "orange",
+  "pink",
+  "yellow",
+];
+
+/**
+ * Generates an avatar background color using the length of a person's full name.
+ *
+ * @param name - Person's full name.
+ * @returns AvatarColors.
+ * @example
+ * getAvatarColor("Pam Beesly")
+ * // returns "sky"
+ */
+
+export const getAvatarColor = (name: string): string =>
+  avatarColorOptions[name.length % avatarColorOptions.length];

--- a/packages/components/src/components/Avatar/index.ts
+++ b/packages/components/src/components/Avatar/index.ts
@@ -1,1 +1,2 @@
 export * from "./Avatar";
+export * from "./getAvatarColor";

--- a/packages/components/src/components/RichText/RichText.tsx
+++ b/packages/components/src/components/RichText/RichText.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
-import parse, {
-  Element,
-  HTMLReactParserOptions,
-  domToReact,
-} from "html-react-parser";
+import parse, { HTMLReactParserOptions, domToReact } from "html-react-parser";
+import type { Element } from "html-react-parser";
 import toUpper from "lodash/toUpper";
 import { Heading } from "../Heading";
 import { Paragraph } from "../Paragraph";

--- a/packages/design-tokens/src/tokens/color.tokens.json
+++ b/packages/design-tokens/src/tokens/color.tokens.json
@@ -138,8 +138,23 @@
     "icon-stronger": {
       "value": "#0F172A"
     },
-    "avatar-initials": {
-      "value": "#4A63FC"
+    "avatar-background-blue": {
+      "value": "#B8C2FF"
+    },
+    "avatar-background-green": {
+      "value": "#8AFECC"
+    },
+    "avatar-background-orange": {
+      "value": "#FBBF24"
+    },
+    "avatar-background-yellow": {
+      "value": "#FDE68A"
+    },
+    "avatar-background-light-blue": {
+      "value": "#A9EBE8"
+    },
+    "avatar-background-pink": {
+      "value": "#A9EBE8"
     }
   }
 }

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -20,7 +20,12 @@ Object {
     "default": "1px solid transparent",
   },
   "colors": Object {
-    "colorAvatarInitials": "#4A63FC",
+    "colorAvatarBackgroundBlue": "#B8C2FF",
+    "colorAvatarBackgroundGreen": "#8AFECC",
+    "colorAvatarBackgroundLightBlue": "#A9EBE8",
+    "colorAvatarBackgroundOrange": "#FBBF24",
+    "colorAvatarBackgroundPink": "#A9EBE8",
+    "colorAvatarBackgroundYellow": "#FDE68A",
     "colorBackground": "#FFFFFF",
     "colorBackgroundBody": "#F7F9FF",
     "colorBackgroundComplete": "linear-gradient(360deg, rgba(82, 244, 174, 0.12) 0%, rgba(131, 247, 197, 0.0575) 57.81%, rgba(255, 255, 255, 0) 100%)",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -63,7 +63,12 @@ export const theme = {
     colorIconWeak: "#64748B",
     colorIconStrong: "#334155",
     colorIconStronger: "#0F172A",
-    colorAvatarInitials: "#4A63FC",
+    colorAvatarBackgroundBlue: "#B8C2FF",
+    colorAvatarBackgroundGreen: "#8AFECC",
+    colorAvatarBackgroundOrange: "#FBBF24",
+    colorAvatarBackgroundYellow: "#FDE68A",
+    colorAvatarBackgroundLightBlue: "#A9EBE8",
+    colorAvatarBackgroundPink: "#A9EBE8",
   },
   fontSizes: {
     fontSize10: "0.75rem", // 12px


### PR DESCRIPTION
## Description of the change

Added a `getAvatarColor` function to randomly generate an Avatar background color. This function isn't used by default, but exported so it can be used in other applications.

![Screen Shot 2022-11-01 at 11 55 40](https://user-images.githubusercontent.com/1350081/199291378-bc8fae4e-c562-41d3-a928-414a10865b65.png)

![Screen Shot 2022-11-01 at 11 55 34](https://user-images.githubusercontent.com/1350081/199291381-33895957-7c0f-4d41-91a4-33207f9bb666.png)


Also added the new avatar background color tokens to the theme and design tokens packages.

## Testing the change

- [ ] Fire up storybook and view the new avatar story

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
