### PR TITLE
feat(components): added Modal component

### DIFF
--- a/.changeset/funny-toes-melt.md
+++ b/.changeset/funny-toes-melt.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+- Added a backdrop state to the theme for future use.
+- Added initial modal backdrop styles to the base styles.

--- a/.changeset/silly-terms-drum.md
+++ b/.changeset/silly-terms-drum.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Modal]: Inital release of the modal component
+[Button]: Changed the as prop to `keyof JSX.IntrinsicElements` to support rendering the Button as another component.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^28.1.4",
+    "assert": "^2.0.0",
     "cspell": "^6.12.0",
     "danger": "^11.1.4",
     "eslint": "^8.25.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,12 +27,19 @@
     "test": "jest",
     "tsc": "tsc"
   },
+  "dependencies": {
+    "@heroicons/react": "^2.0.12",
+    "@radix-ui/react-checkbox": "^1.0.1",
+    "@radix-ui/react-progress": "^1.0.1",
+    "ariakit": "^2.0.0-next.41"
+  },
   "peerDependencies": {
     "@heroicons/react": "^2.0.12",
     "@localyze-pluto/theme": "^1.2.3",
     "@radix-ui/react-checkbox": "^1.0.1",
     "@radix-ui/react-progress": "^1.0.1",
     "@xstyled/styled-components": "^3.6.0",
+    "ariakit": "^2.0.0-next.41",
     "html-react-parser": "^3.0.4",
     "lodash": "^4.17.21",
     "react": "^17.0.2 || ^18.2.0",
@@ -56,6 +63,7 @@
     "@types/react-dom": "^17.0.2",
     "@types/styled-components": "^5.1.26",
     "@xstyled/styled-components": "^3.6.0",
+    "chromatic": "^6.11.4",
     "eslint": "^8.25.0",
     "html-react-parser": "^3.0.4",
     "jest": "^28.1.2",

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -13,8 +13,8 @@ export interface ButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "color"> {
   /** Sets the variant of the button. */
   variant: ButtonVariantOptions;
-  /** Sets the render element of the component. Either 'a' or 'button'.*/
-  as?: "a" | "button" | "label";
+  /** Sets the render element of the component. */
+  as?: keyof JSX.IntrinsicElements;
   /** Button content */
   children?: React.ReactNode;
   /** If used as an 'a', the href is url that the link point to. */

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,256 @@
+import type { ComponentMeta } from "@storybook/react";
+import React from "react";
+import isChromatic from "chromatic/isChromatic";
+import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
+import { Paragraph } from "../Paragraph";
+import {
+  useModalState,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  ModalSubHeading,
+} from "./index";
+
+export default {
+  component: Modal,
+  title: "Components/Modal",
+} as ComponentMeta<typeof Modal>;
+
+export const Default = (): JSX.Element => {
+  const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
+  return (
+    <Box.div h="1000px" w="1350px">
+      <Button onClick={modal.toggle} variant="primary">
+        Open modal
+      </Button>
+      <Modal state={modal}>
+        <ModalHeader>
+          <ModalHeading>This is the heading</ModalHeading>
+        </ModalHeader>
+        <ModalBody>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={modal.toggle} variant="secondary">
+            Back
+          </Button>
+          <Button onClick={modal.toggle} variant="primary">
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box.div>
+  );
+};
+
+export const NoPaddingOnBody = (): React.ReactNode => {
+  const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
+  return (
+    <Box.div h="1000px" w="1350px">
+      <Button onClick={modal.toggle} variant="primary">
+        Open modal
+      </Button>
+      <Modal state={modal}>
+        <ModalHeader>
+          <ModalHeading>This is the heading</ModalHeading>
+          <ModalSubHeading>This is the sub heading</ModalSubHeading>
+        </ModalHeader>
+        <ModalBody padding="space0">
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={modal.toggle} variant="secondary">
+            Back
+          </Button>
+          <Button onClick={modal.toggle} variant="primary">
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box.div>
+  );
+};
+
+export const OverflowBodyContent = (): React.ReactNode => {
+  const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
+  return (
+    <Box.div h="1000px" w="1350px">
+      <Button onClick={modal.toggle} variant="primary">
+        Open modal
+      </Button>
+      <Modal state={modal}>
+        <ModalHeader>
+          <ModalHeading>This is the heading</ModalHeading>
+          <ModalSubHeading>This is the sub heading</ModalSubHeading>
+        </ModalHeader>
+        <ModalBody>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={modal.toggle} variant="secondary">
+            Back
+          </Button>
+          <Button onClick={modal.toggle} variant="primary">
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box.div>
+  );
+};
+
+export const ReallyLongHeader = (): React.ReactNode => {
+  const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
+  return (
+    <Box.div h="1000px" w="1350px">
+      <Button onClick={modal.toggle} variant="primary">
+        Open modal
+      </Button>
+      <Modal state={modal}>
+        <ModalHeader>
+          <ModalHeading>
+            This is a really long header that should wrap to multiple lines. The
+            width of the modal should make it wrap.
+          </ModalHeading>
+          <ModalSubHeading>This is the sub heading</ModalSubHeading>
+        </ModalHeader>
+        <ModalBody>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={modal.toggle} variant="secondary">
+            Back
+          </Button>
+          <Button onClick={modal.toggle} variant="primary">
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box.div>
+  );
+};
+
+export const InitialFocus = (): JSX.Element => {
+  const buttonRef = React.createRef<HTMLButtonElement>();
+  const modal = useModalState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  return (
+    <Box.div h="1000px" w="1350px">
+      <Button onClick={modal.toggle} variant="primary">
+        Open modal
+      </Button>
+      <Modal initialFocusRef={buttonRef} state={modal}>
+        <ModalHeader>
+          <ModalHeading>This is the heading</ModalHeading>
+          <ModalSubHeading>This is the sub heading</ModalSubHeading>
+        </ModalHeader>
+        <ModalBody>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={modal.toggle} variant="secondary">
+            Back
+          </Button>
+          <Button onClick={modal.toggle} ref={buttonRef} variant="primary">
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box.div>
+  );
+};

--- a/packages/components/src/components/Modal/Modal.test.tsx
+++ b/packages/components/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Default } from "./Modal.stories";
+
+const OPEN_MODAL_TEXT = "Open modal";
+
+describe("<Modal />", () => {
+  it("should open and close a modal using the close modal button", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_MODAL_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    await userEvent.click(renderedOpenButton);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+
+    const renderedCloseButton = screen.getByLabelText("Close modal");
+    expect(renderedCloseButton).toBeInTheDocument();
+
+    await userEvent.click(renderedCloseButton);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should open and close a modal using the primary button", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_MODAL_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    await userEvent.click(renderedOpenButton);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+
+    const renderedPrimaryButton = screen.getByText("Done");
+    expect(renderedPrimaryButton).toBeInTheDocument();
+
+    await userEvent.click(renderedPrimaryButton);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should open and close a modal using the secondary button", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_MODAL_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    await userEvent.click(renderedOpenButton);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+
+    const renderedSecondaryButton = screen.getByText("Back");
+    expect(renderedSecondaryButton).toBeInTheDocument();
+
+    await userEvent.click(renderedSecondaryButton);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should open a modal and close it using the escape key", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_MODAL_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    await userEvent.click(renderedOpenButton);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should open a modal and close it by clicking on the backdrop", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_MODAL_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    await userEvent.click(renderedOpenButton);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+
+    const renderedBackdrop = screen.getByRole("presentation");
+    expect(renderedBackdrop).toBeInTheDocument();
+
+    await userEvent.click(renderedBackdrop);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Dialog } from "ariakit/dialog";
+import type { DialogProps } from "ariakit";
+import { Box } from "../../primitives/Box";
+
+export interface ModalProps extends DialogProps {
+  /** The contents of the modal. */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** A Modal is a page overlay that displays information and blocks interaction with the page until an action is taken or the Modal is dismissed. */
+const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Box.div
+        as={Dialog}
+        backgroundColor="colorBackground"
+        borderRadius="borderRadius30"
+        display="flex"
+        flexDirection="column"
+        left="50%"
+        maxHeight="90vh"
+        maxWidth="47.75rem"
+        position="fixed"
+        ref={ref}
+        top="50%"
+        transform="translate(-50%, -50%)"
+        w="90vw"
+        zIndex="zIndex30"
+        {...props}
+      >
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+Modal.displayName = "Modal";
+
+export { Modal };

--- a/packages/components/src/components/Modal/ModalBody.tsx
+++ b/packages/components/src/components/Modal/ModalBody.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box } from "../../primitives/Box";
+
+export interface ModalBodyProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {
+  /** The contents of the modal body. */
+  children: NonNullable<React.ReactNode>;
+  /** Sets the padding of the modal body. */
+  padding?: "space0" | "space60";
+}
+
+/** The body content area of the modal. */
+const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
+  ({ children, padding = "space60", ...props }, ref) => {
+    return (
+      <Box.div overflowY="auto" padding={padding} ref={ref} {...props}>
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+ModalBody.displayName = "ModalBody";
+
+export { ModalBody };

--- a/packages/components/src/components/Modal/ModalFooter.tsx
+++ b/packages/components/src/components/Modal/ModalFooter.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Box } from "../../primitives/Box";
+
+export interface ModalFooterProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {
+  /** The contents of the modal footer. */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** The footer content area of the modal. */
+const ModalFooter = React.forwardRef<HTMLDivElement, ModalFooterProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Box.div
+        alignItems="center"
+        borderTopColor="colorBorderWeakest"
+        borderTopStyle="borderSolid"
+        borderTopWidth="borderWidth10"
+        display="flex"
+        gap="space30"
+        justifyContent="flex-end"
+        padding="space60"
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+ModalFooter.displayName = "ModalFooter";
+
+export { ModalFooter };

--- a/packages/components/src/components/Modal/ModalHeader.tsx
+++ b/packages/components/src/components/Modal/ModalHeader.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { DialogDismiss } from "ariakit/dialog";
+import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
+
+export interface ModalHeaderProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {
+  /** The contents of the modal header */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** The header content area of the modal. */
+const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Box.div
+        borderBottomColor="colorBorderWeakest"
+        borderBottomStyle="borderSolid"
+        borderBottomWidth="borderWidth10"
+        display="flex"
+        gap="space30"
+        justifyContent="space-between"
+        padding="space60"
+        ref={ref}
+        {...props}
+      >
+        <Box.div>{children}</Box.div>
+        <Box.div>
+          <DialogDismiss
+            aria-label="Close modal"
+            as={Button}
+            iconOnly
+            leadingIcon="XMarkIcon"
+            variant="ghost"
+          />
+        </Box.div>
+      </Box.div>
+    );
+  }
+);
+
+ModalHeader.displayName = "ModalHeader";
+
+export { ModalHeader };

--- a/packages/components/src/components/Modal/ModalHeading.tsx
+++ b/packages/components/src/components/Modal/ModalHeading.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Heading } from "../Heading";
+
+export interface ModalHeadingProps
+  extends Omit<React.HTMLAttributes<HTMLHeadingElement>, "color"> {
+  /** The contents of the modal heading. */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** The heading of the modal. */
+const ModalHeading = React.forwardRef<HTMLHeadingElement, ModalHeadingProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Heading
+        as="h2"
+        color="colorTextHeadingStronger"
+        marginBottom="space0"
+        ref={ref}
+        size="heading60"
+        {...props}
+      >
+        {children}
+      </Heading>
+    );
+  }
+);
+
+ModalHeading.displayName = "ModalHeading";
+
+export { ModalHeading };

--- a/packages/components/src/components/Modal/ModalSubHeading.tsx
+++ b/packages/components/src/components/Modal/ModalSubHeading.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Box } from "../../primitives/Box";
+import { Text } from "../../primitives/Text";
+
+export interface ModalSubHeadingProps
+  extends Omit<React.HTMLAttributes<HTMLHeadingElement>, "color"> {
+  /** The contents of the modal sub heading. */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** The subheading of the modal. */
+const ModalSubHeading = React.forwardRef<
+  HTMLHeadingElement,
+  ModalSubHeadingProps
+>(({ children, ...props }, ref) => {
+  return (
+    <Box.div marginTop="space10">
+      <Text.h3
+        color="colorText"
+        fontFamily="fontFamilyModerat"
+        fontSize="fontSize20"
+        fontWeight="fontWeightRegular"
+        lineHeight="lineHeight20"
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </Text.h3>
+    </Box.div>
+  );
+});
+
+ModalSubHeading.displayName = "ModalSubHeading";
+
+export { ModalSubHeading };

--- a/packages/components/src/components/Modal/index.ts
+++ b/packages/components/src/components/Modal/index.ts
@@ -1,0 +1,9 @@
+export * from "./Modal";
+export * from "./ModalBody";
+export * from "./ModalFooter";
+export * from "./ModalHeader";
+export * from "./ModalHeading";
+export * from "./ModalSubHeading";
+export { useDialogState as useModalState } from "ariakit";
+export type { DialogStateProps as ModalStateProps } from "ariakit";
+export type { DialogState as ModalState } from "ariakit";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -11,6 +11,7 @@ export * from "./components/Icon";
 export * from "./components/Input";
 export * from "./components/InputBox";
 export * from "./components/Label";
+export * from "./components/Modal";
 export * from "./components/ProgressBar";
 export * from "./components/Paragraph";
 export * from "./components/RichText";

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -223,6 +223,7 @@ Object {
   "states": Object {
     "_": null,
     "active": "&:active",
+    "backdrop": "&[data-backdrop]",
     "checked": "&:checked",
     "disabled": "&:disabled, &[aria-disabled=true]",
     "even": "&:even",

--- a/packages/theme/src/styles/base.tsx
+++ b/packages/theme/src/styles/base.tsx
@@ -9,4 +9,8 @@ export const BaseStyles = createGlobalStyle`
     font-variant-numeric: tabular-nums;
     line-height: lineHeight30;
   }
+
+  [data-backdrop] {
+    background-color: rgba(100, 116, 139, 0.75);
+  }
 `;

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -168,6 +168,7 @@ export const theme = {
   },
   states: {
     ...defaultTheme.states,
+    backdrop: "&[data-backdrop]",
     hidden: '&[data-hidden="true"]',
     loading: '&[aria-busy="true"]',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,7 +1803,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@discoveryjs/json-ext@^0.5.3":
+"@discoveryjs/json-ext@^0.5.3", "@discoveryjs/json-ext@^0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
@@ -1863,6 +1863,18 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.4.tgz#cc0f2a03db7193b1b932b90d09c5c81235682a60"
+  integrity sha512-maYJRv+sAXTy4K9mzdv0JPyNW5YPVHrqtY90tEdI6XNpuLOP26Ci2pfwPsKBA/Wh4Z3FX5sUrtUFTdMYj9v+ug==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -4109,7 +4121,7 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/webpack-env@^1.16.0":
+"@types/webpack-env@^1.16.0", "@types/webpack-env@^1.17.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.0.tgz#ed6ecaa8e5ed5dfe8b2b3d00181702c9925f13fb"
   integrity sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==
@@ -4684,6 +4696,19 @@ aria-query@^5.0.0:
   dependencies:
     deep-equal "^2.0.5"
 
+ariakit-utils@0.17.0-next.26:
+  version "0.17.0-next.26"
+  resolved "https://registry.yarnpkg.com/ariakit-utils/-/ariakit-utils-0.17.0-next.26.tgz#585ccf021f9271c4ac0be2753ccf49bbd88bfaae"
+  integrity sha512-Su1MA0nWcMKI/lPS++jgkXek6Z+Az4SGOTIjGz2mn7kN6pSRO3Xm4gW/6gLpbu0kmVd+MYNSpmEvFnJUf/udhA==
+
+ariakit@^2.0.0-next.41:
+  version "2.0.0-next.41"
+  resolved "https://registry.yarnpkg.com/ariakit/-/ariakit-2.0.0-next.41.tgz#ea23521c18c30dd5daf3f48976f879710d968dca"
+  integrity sha512-79ACgnIofsC7ULirjz/dqjNCwUW9TmX7ULdCqHHrpJP1H+lw9vtpWv4eeuRAII2lsyfNtXmLnY6qZ1ZV3ucxmA==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+    ariakit-utils "0.17.0-next.26"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -4818,6 +4843,16 @@ arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
+assert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
+  dependencies:
+    es6-object-assign "^1.1.0"
+    is-nan "^1.2.1"
+    object-is "^1.0.1"
+    util "^0.12.0"
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -5579,6 +5614,14 @@ chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+chromatic@^6.11.4:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.11.4.tgz#1bb72bceb8f4455694e9e27db86c585e8b7cb7cd"
+  integrity sha512-f1TcuIXKjGUuOjPuwFF44kzbuEcESFcDxHzrzWPLmHuC90dV8HLxbufqYaTOBYMO/rJ32Zftb7S9pXuF/Rhfog==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.7"
+    "@types/webpack-env" "^1.17.0"
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -6971,6 +7014,11 @@ es5-shim@^4.5.13:
   version "4.6.7"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.6.7.tgz#bc67ae0fc3dd520636e0a1601cc73b450ad3e955"
   integrity sha512-jg21/dmlrNQI7JyyA2w7n+yifSxBng0ZralnSfVZjoCawgNTCnS+yBCyVM9DL5itm7SUnDGgv7hcq2XCZX4iRQ==
+
+es6-object-assign@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==
 
 es6-shim@^0.35.5:
   version "0.35.6"
@@ -8374,6 +8422,13 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 got@^11.1.4:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
@@ -9178,6 +9233,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@^3.0.0, is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -9211,6 +9273,14 @@ is-map@^2.0.1, is-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
+is-nan@^1.2.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -9352,6 +9422,17 @@ is-text-path@^1.0.1:
   integrity sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==
   dependencies:
     text-extensions "^1.0.0"
+
+is-typed-array@^1.1.3:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 is-typed-array@^1.1.9:
   version "1.1.9"
@@ -11329,7 +11410,7 @@ object-inspect@^1.12.2, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
-object-is@^1.1.4:
+object-is@^1.0.1, object-is@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
   integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
@@ -14569,6 +14650,17 @@ util.promisify@1.0.0:
   dependencies:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
+
+util@^0.12.0:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
 
 utila@~0.4:
   version "0.4.0"


### PR DESCRIPTION
## Description of the change

This PR adds the initial release of the modal component. The component uses the [AriaKit](https://ariakit.org/components/dialog) primitive to handle the modal functionality. Currently I'm leaving the modal API pretty open, as in straight exports from AriaKit. This is mainly to get a feel for how this modal will work with the current application. We will be adding a more dev friendly modal in the future where the api will be more refined. I have also not included any animations in this first version. Because of the way the primitive is built, we'll need to setup an animation library like Framer first in Pluto. I'd like to spend more time researching Framer or another option first before adding animations in this PR.

This also includes an update to the theme to include the backdrop styles.

![Screen Shot 2022-11-07 at 13 32 06](https://user-images.githubusercontent.com/1350081/200398267-b28cdb6d-24b8-4af7-83f4-b51c013eb83d.png)

## Testing the change

- [ ] Check out the storybook stories

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
