### PR TITLE
feat(components): add extra-large size to Avatar

### DIFF
--- a/.changeset/tall-clouds-happen.md
+++ b/.changeset/tall-clouds-happen.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Avatar]: Add xlarge size to Avatar and updated fontWeight of initials

--- a/packages/components/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/components/src/components/Avatar/Avatar.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import map from "lodash/map";
+import dropRight from "lodash/dropRight";
 import React from "react";
 import { Box } from "../../primitives/Box";
 import { Avatar, AvatarSizeOptions } from "./Avatar";
@@ -11,7 +12,13 @@ export default {
   title: "Components/Avatar",
 } as ComponentMeta<typeof Avatar>;
 
-const sizes: AvatarSizeOptions[] = ["xsmall", "small", "medium", "large"];
+const sizes: AvatarSizeOptions[] = [
+  "xsmall",
+  "small",
+  "medium",
+  "large",
+  "xlarge",
+];
 
 const Template: ComponentStory<typeof Avatar> = (args) => (
   <Box.div alignItems="center" display="flex" gap="space30" maxWidth="680px">
@@ -38,11 +45,17 @@ Initials.args = {
   name: "Liza Wang",
 };
 
-export const WithName = Template.bind({});
-WithName.args = {
-  ...defaultArgs,
-  showName: true,
-};
+export const WithName = (): JSX.Element => (
+  <Box.div alignItems="center" display="flex" gap="space30" maxWidth="680px">
+    {map(dropRight(sizes), (size: AvatarSizeOptions) => {
+      return (
+        <Box.div padding="space60">
+          <Avatar size={size} {...defaultArgs} showName />
+        </Box.div>
+      );
+    })}
+  </Box.div>
+);
 
 export const InitialsAndBackgroundColors: ComponentStory<
   typeof Avatar

--- a/packages/components/src/components/Avatar/Avatar.tsx
+++ b/packages/components/src/components/Avatar/Avatar.tsx
@@ -14,7 +14,12 @@ export type AvatarColorOptions =
   | "pink"
   | "yellow";
 
-export type AvatarSizeOptions = "large" | "medium" | "small" | "xsmall";
+export type AvatarSizeOptions =
+  | "large"
+  | "medium"
+  | "small"
+  | "xlarge"
+  | "xsmall";
 
 export type AvatarProps = {
   /** The color used for the avatar background. */
@@ -54,6 +59,12 @@ const getAvatarSizes = (
         h: "40px",
       };
     }
+    case "xlarge": {
+      return {
+        w: "120px",
+        h: "120px",
+      };
+    }
     default: {
       return {
         w: "32px",
@@ -63,10 +74,11 @@ const getAvatarSizes = (
   }
 };
 
-const getInitialsSizes = (
+const getInitialsStyles = (
   size: AvatarSizeOptions
 ): {
   fontSize?: SystemProp<keyof Theme["fontSizes"], Theme>;
+  fontWeight?: SystemProp<keyof Theme["fontWeights"], Theme>;
   style?: React.CSSProperties;
 } => {
   switch (size) {
@@ -83,6 +95,12 @@ const getInitialsSizes = (
     case "large": {
       return {
         fontSize: "fontSize30",
+      };
+    }
+    case "xlarge": {
+      return {
+        fontSize: "fontSize70",
+        fontWeight: "fontWeightBold",
       };
     }
     default: {
@@ -209,7 +227,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
             <Box.span
               aria-hidden={true}
               color="colorTextStronger"
-              {...getInitialsSizes(size)}
+              {...getInitialsStyles(size)}
             >
               {getInitials(name)}
             </Box.span>


### PR DESCRIPTION
## Description of the change

Adds the **extra-large** size to Avatar component.

![image](https://user-images.githubusercontent.com/5320963/201112064-9c10296b-742c-4560-bb0d-7a83ff2a937c.png)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
