### PR TITLE
fix: [FileUploaderButton] call onClick prop

### DIFF
--- a/.changeset/cool-seas-end.md
+++ b/.changeset/cool-seas-end.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Calls onClick function when clicking on FileUploaderButton

--- a/packages/components/src/components/FileUploader/FileUploaderButton.test.tsx
+++ b/packages/components/src/components/FileUploader/FileUploaderButton.test.tsx
@@ -30,6 +30,25 @@ describe("<FileUploaderButton />", () => {
     expect((input as HTMLInputElement).files).toHaveLength(1);
   });
 
+  it("calls onClick", async () => {
+    const mockOnClick = jest.fn();
+
+    render(
+      <FileUploaderButton
+        id="file-uploader"
+        onChange={jest.fn()}
+        onClick={mockOnClick}
+        variant="primary"
+      >
+        Upload
+      </FileUploaderButton>
+    );
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
   it("passes accept file extensions to inner input element", () => {
     render(
       <FileUploaderButton

--- a/packages/components/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/components/src/components/FileUploader/FileUploaderButton.tsx
@@ -3,9 +3,13 @@ import React, { useRef } from "react";
 import { Box } from "../../primitives/Box";
 import { Button, ButtonProps } from "../Button";
 
-export interface FileUploaderButtonProps extends Omit<ButtonProps, "onChange"> {
+export interface FileUploaderButtonProps
+  extends Omit<ButtonProps, "onChange" | "onClick"> {
   /** It is called when user selects a file */
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+
+  /** It is called when user clicks on the button */
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 
   /** The acceptable file types/extensions */
   accept?: string;
@@ -15,9 +19,14 @@ export interface FileUploaderButtonProps extends Omit<ButtonProps, "onChange"> {
 const FileUploaderButton = React.forwardRef<
   HTMLButtonElement,
   FileUploaderButtonProps
->(({ id, onChange, accept, disabled, ...props }, ref) => {
+>(({ id, onChange, onClick, accept, disabled, ...props }, ref) => {
   const inputRef = useRef(null);
-  const clickInput = () => invoke(inputRef.current, "click") as void;
+  const clickInput = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    invoke(inputRef.current, "click") as void;
+    if (onClick) onClick(event);
+  };
   return (
     <>
       <Button


### PR DESCRIPTION
## Description of the change
The upload button was replacing the onClick with its own implementation. So, if we added an `onClick` prop, which is allowed, it would never be called.

## Testing the change
- See the tests

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
