### PR TITLE
feat(tokens): add new background colors to the default theme

### DIFF
--- a/.changeset/spicy-zebras-dream.md
+++ b/.changeset/spicy-zebras-dream.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": minor
+---
+
+[Default Theme] Add new background colors

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -30,6 +30,8 @@ Object {
     "colorBackgroundBody": "#F7F9FF",
     "colorBackgroundBodyStrong": "#1E293B",
     "colorBackgroundComplete": "linear-gradient(360deg, rgba(82, 244, 174, 0.12) 0%, rgba(131, 247, 197, 0.0575) 57.81%, rgba(255, 255, 255, 0) 100%)",
+    "colorBackgroundDecorativeStrong": "#C8F0EF",
+    "colorBackgroundDecorativeWeak": "#FFF1DB",
     "colorBackgroundDestructive": "#DC2626",
     "colorBackgroundDestructiveStrong": "#B91C1C",
     "colorBackgroundError": "#FEF2F2",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -34,6 +34,8 @@ export const theme = {
     colorBackgroundPrimary: "#102EE9",
     colorBackgroundPrimaryStrong: "#0B1F9C",
     colorBackgroundPrimaryStrongest: "#041162",
+    colorBackgroundDecorativeWeak: "#FFF1DB",
+    colorBackgroundDecorativeStrong: "#C8F0EF",
     colorBackgroundDestructive: "#DC2626",
     colorBackgroundDestructiveStrong: "#B91C1C",
     colorBackgroundInfo: "#EBEDFF",


### PR DESCRIPTION
## Description of the change

Adds the new decorative01 and decorative02  background colors to the default theme.

## Testing the change

- [x] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
