### PR TITLE
feat(components): add Tooltip component

### DIFF
--- a/.changeset/late-eels-protect.md
+++ b/.changeset/late-eels-protect.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Tooltip]: Initial release of the tooltip component.

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -17,6 +17,9 @@ import {
 export default {
   component: Modal,
   title: "Components/Modal",
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
 } as ComponentMeta<typeof Modal>;
 
 export const Default = (): JSX.Element => {

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,244 @@
+import type { ComponentMeta } from "@storybook/react";
+import React from "react";
+import isChromatic from "chromatic/isChromatic";
+import { Anchor } from "../Anchor";
+import { Button } from "../Button";
+import { Box } from "../../primitives/Box";
+import { useTooltipState, Tooltip, TooltipAnchor } from "./index";
+
+export default {
+  component: Tooltip,
+  title: "Components/Tooltip",
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
+} as ComponentMeta<typeof Tooltip>;
+
+export const Default = (): JSX.Element => {
+  const tooltip = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  return (
+    <>
+      <TooltipAnchor as={Button} state={tooltip} variant="secondary">
+        Hover or focus on me
+      </TooltipAnchor>
+      <Tooltip state={tooltip}>This is the content of the tooltip.</Tooltip>
+    </>
+  );
+};
+
+export const AnchorBased = (): JSX.Element => {
+  const tooltip = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  return (
+    <>
+      <TooltipAnchor as={Anchor} href="#" state={tooltip}>
+        Hover or focus on me
+      </TooltipAnchor>
+      <Tooltip state={tooltip}>This is the content of the tooltip.</Tooltip>
+    </>
+  );
+};
+
+export const RightAligned = (): JSX.Element => {
+  const tooltip = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+    placement: "right",
+  });
+  return (
+    <>
+      <TooltipAnchor as={Button} state={tooltip} variant="secondary">
+        Hover or focus on me
+      </TooltipAnchor>
+      <Tooltip state={tooltip}>This is the content of the tooltip.</Tooltip>
+    </>
+  );
+};
+
+export const BottomAligned = (): JSX.Element => {
+  const tooltip = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+    placement: "bottom",
+  });
+  return (
+    <>
+      <TooltipAnchor as={Button} state={tooltip} variant="primary">
+        Hover or focus on me
+      </TooltipAnchor>
+      <Tooltip state={tooltip}>This is the content of the tooltip.</Tooltip>
+    </>
+  );
+};
+
+export const LeftAligned = (): JSX.Element => {
+  const tooltip = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+    placement: "left",
+  });
+  return (
+    <Box.div display="flex" justifyContent="flex-end">
+      <TooltipAnchor as={Button} state={tooltip} variant="primary">
+        Hover or focus on me
+      </TooltipAnchor>
+      <Tooltip state={tooltip}>This is the content of the tooltip.</Tooltip>
+    </Box.div>
+  );
+};
+
+export const MultilineOpen = (): JSX.Element => {
+  const tooltipOne = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipTwo = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipThree = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipFour = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipFive = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipSix = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+
+  return (
+    <Box.div
+      display="grid"
+      gridTemplateColumns="repeat(3, max-content)"
+      justifyContent="space-between"
+      rowGap="18rem"
+    >
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipOne} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipOne}>
+          This is the content of the tooltip. It should be on multiple lines.
+        </Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipTwo} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipTwo}>
+          This is the content of the tooltip. It should be on multiple lines.
+        </Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipThree} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipThree}>
+          This is the content of the tooltip. It should be on multiple lines.
+        </Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipFour} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipFour}>
+          This is the content of the tooltip. It should be on multiple lines.
+        </Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipFive} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipFive}>
+          This is the content of the tooltip. It should be on multiple lines.
+        </Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipSix} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipSix}>
+          This is the content of the tooltip. It should be on multiple lines.
+        </Tooltip>
+      </Box.div>
+    </Box.div>
+  );
+};
+
+export const SinglelineOpen = (): JSX.Element => {
+  const tooltipOne = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipTwo = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipThree = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipFour = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipFive = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const tooltipSix = useTooltipState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+
+  return (
+    <Box.div
+      display="grid"
+      gridTemplateColumns="repeat(3, max-content)"
+      justifyContent="space-between"
+      rowGap="18rem"
+    >
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipOne} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipOne}>Approved</Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipTwo} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipTwo}>Approved</Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipThree} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipThree}>Approved</Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipFour} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipFour}>Approved</Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipFive} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipFive}>Approved</Tooltip>
+      </Box.div>
+
+      <Box.div>
+        <TooltipAnchor as={Button} state={tooltipSix} variant="secondary">
+          Hover or focus on me
+        </TooltipAnchor>
+        <Tooltip state={tooltipSix}>Approved</Tooltip>
+      </Box.div>
+    </Box.div>
+  );
+};

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { Default as TooltipContainer } from "./Tooltip.stories";
+import { Default as TooltipComponent } from "./Tooltip.stories";
 
 const OPEN_TOOLTIP_TEXT = "Hover or focus on me";
 
 describe("<Tooltip />", () => {
   it("should open and close a tooltip on hover", async () => {
-    render(<Default />);
+    render(<TooltipComponent />);
     const renderedOpenButton = screen.getByText(OPEN_TOOLTIP_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 
@@ -19,7 +19,7 @@ describe("<Tooltip />", () => {
   });
 
   it("should open and close a tooltip on focus", async () => {
-    render(<Default />);
+    render(<TooltipComponent />);
     const renderedOpenButton = screen.getByText(OPEN_TOOLTIP_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { Default } from "./Tooltip.stories";
+import { Default as TooltipContainer } from "./Tooltip.stories";
 
 const OPEN_TOOLTIP_TEXT = "Hover or focus on me";
 

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Default } from "./Tooltip.stories";
+
+const OPEN_TOOLTIP_TEXT = "Hover or focus on me";
+
+describe("<Tooltip />", () => {
+  it("should open and close a tooltip on hover", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_TOOLTIP_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    await userEvent.hover(renderedOpenButton);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await userEvent.unhover(renderedOpenButton);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("should open and close a tooltip on focus", async () => {
+    render(<Default />);
+    const renderedOpenButton = screen.getByText(OPEN_TOOLTIP_TEXT);
+    expect(renderedOpenButton).toBeInTheDocument();
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+    expect(renderedOpenButton).toHaveFocus();
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await userEvent.tab();
+    expect(renderedOpenButton).not.toHaveFocus();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Tooltip as TooltipPrimitive, TooltipArrow } from "ariakit";
+import type { TooltipProps as TooltipPrimitiveProps } from "ariakit";
+import { Box } from "../../primitives/Box";
+
+export interface TooltipProps extends TooltipPrimitiveProps {
+  /** The contents of the tooltip. */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** A tooltip is a page overlay that displays non interactive clarifying text related to an element that's in a focused or hovered state. */
+const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Box.div
+        as={TooltipPrimitive}
+        backgroundColor="colorBackgroundBodyStrong"
+        borderRadius="borderRadius30"
+        color="colorTextInverse"
+        fontSize="fontSize20"
+        lineHeight="lineHeight20"
+        maxWidth="200px"
+        padding="space40"
+        ref={ref}
+        {...props}
+      >
+        <TooltipArrow />
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+Tooltip.displayName = "Tooltip";
+
+export { Tooltip };

--- a/packages/components/src/components/Tooltip/index.ts
+++ b/packages/components/src/components/Tooltip/index.ts
@@ -1,0 +1,4 @@
+export * from "./Tooltip";
+export { TooltipAnchor, useTooltipState } from "ariakit";
+export type { TooltipState } from "ariakit";
+export type { TooltipStateProps } from "ariakit";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -19,5 +19,6 @@ export * from "./components/RichText";
 export * from "./components/Search";
 export * from "./components/Table";
 export * from "./components/Textarea";
+export * from "./components/Tooltip";
 export * from "./primitives/Box";
 export * from "./primitives/Text";


### PR DESCRIPTION
## Description of the change

This PR adds the initial release of the tooltip component. The component uses the [AriaKit](https://ariakit.org/components/tooltip) primitive to handle the functionality. Currently I'm leaving the tooltip API pretty open, as in straight exports from AriaKit. This is mainly to get a feel for how this tooltip will work with the current application. We will be adding a more dev friendly tooltip in the future where the api will be more refined. I have also not included any animations in this first version. Because of the way the primitive is built, we'll need to setup an animation library like Framer first in Pluto. I'd like to spend more time researching Framer or another option first before adding animations in this PR.

<img width="1204" alt="Screenshot 2022-11-14 at 16 15 48" src="https://user-images.githubusercontent.com/1350081/201780008-f50a70e9-6aea-4452-b56f-dcc2b1d75402.png">

## Testing the change

- [ ] Check out the storybook stories

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
