### PR TITLE
fix(components): add rel and target as props on the button

### DIFF
--- a/.changeset/poor-hornets-cheer.md
+++ b/.changeset/poor-hornets-cheer.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Add target and rel as prop on the Button component

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -19,6 +19,10 @@ export interface ButtonProps
   children?: React.ReactNode;
   /** If used as an 'a', the href is url that the link point to. */
   href?: string;
+  /** If used as an 'a', the target attribute tells the browser where the linked document should be loaded. */
+  target?: React.AnchorHTMLAttributes<HTMLAnchorElement>["target"];
+  /** If used as an 'a', the rel attribute defines the relationship between a linked resource and the current document. */
+  rel?: React.AnchorHTMLAttributes<HTMLAnchorElement>["rel"];
   /** Sets the button to be disabled. */
   disabled?: boolean;
   /** Icon to be added on the left of the content. */


### PR DESCRIPTION
## Description of the change
Allow buttons to receive `target` and `rel` as prop to use with `as="a"`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
