### PR TITLE
fix(components): omit noonce from ariakit props

### DIFF
--- a/.changeset/dull-apples-relate.md
+++ b/.changeset/dull-apples-relate.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/components": patch
+---
+
+- [Modal]: Omit `noonce` from ModalProps to fix bug in compiled application.
+- [Tooltip]: Omit `noonce` from TooltipProps to fix bug in compiled application.

--- a/cspell.json
+++ b/cspell.json
@@ -23,7 +23,8 @@
     "xlarge",
     "xsmall",
     "unhover",
-    "uppy"
+    "uppy",
+    "noonce"
   ],
   "flagWords": ["hte"],
   "allowCompoundWords": true,

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -17,9 +17,6 @@ import {
 export default {
   component: Modal,
   title: "Components/Modal",
-  parameters: {
-    chromatic: { delay: 1000 },
-  },
 } as ComponentMeta<typeof Modal>;
 
 export const Default = (): JSX.Element => {
@@ -60,6 +57,10 @@ export const Default = (): JSX.Element => {
   );
 };
 
+Default.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
+};
+
 export const NoPaddingOnBody = (): React.ReactNode => {
   const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
   return (
@@ -97,6 +98,10 @@ export const NoPaddingOnBody = (): React.ReactNode => {
       </Modal>
     </Box.div>
   );
+};
+
+NoPaddingOnBody.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
 };
 
 export const OverflowBodyContent = (): React.ReactNode => {
@@ -174,6 +179,10 @@ export const OverflowBodyContent = (): React.ReactNode => {
   );
 };
 
+OverflowBodyContent.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
+};
+
 export const ReallyLongHeader = (): React.ReactNode => {
   const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
   return (
@@ -216,6 +225,10 @@ export const ReallyLongHeader = (): React.ReactNode => {
   );
 };
 
+ReallyLongHeader.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
+};
+
 export const InitialFocus = (): JSX.Element => {
   const buttonRef = React.createRef<HTMLButtonElement>();
   const modal = useModalState({
@@ -256,4 +269,8 @@ export const InitialFocus = (): JSX.Element => {
       </Modal>
     </Box.div>
   );
+};
+
+InitialFocus.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
 };

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -21,7 +21,6 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         left="50%"
         maxHeight="90vh"
         maxWidth="47.75rem"
-        nonce={undefined}
         position="fixed"
         ref={ref}
         top="50%"

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -3,7 +3,7 @@ import { Dialog } from "ariakit/dialog";
 import type { DialogProps } from "ariakit";
 import { Box } from "../../primitives/Box";
 
-export interface ModalProps extends DialogProps {
+export interface ModalProps extends Omit<DialogProps, "noonce"> {
   /** The contents of the modal. */
   children: NonNullable<React.ReactNode>;
 }
@@ -21,6 +21,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         left="50%"
         maxHeight="90vh"
         maxWidth="47.75rem"
+        nonce={undefined}
         position="fixed"
         ref={ref}
         top="50%"

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -3,7 +3,7 @@ import { Tooltip as TooltipPrimitive, TooltipArrow } from "ariakit";
 import type { TooltipProps as TooltipPrimitiveProps } from "ariakit";
 import { Box } from "../../primitives/Box";
 
-export interface TooltipProps extends TooltipPrimitiveProps {
+export interface TooltipProps extends Omit<TooltipPrimitiveProps, "noonce"> {
   /** The contents of the tooltip. */
   children: NonNullable<React.ReactNode>;
 }


### PR DESCRIPTION
## Description of the change

Fixes the `noonce` typescript error we're seeing when using Modal and Tooltip in the client application.

![Screenshot 2022-11-22 at 09 20 48](https://user-images.githubusercontent.com/1350081/203352181-f555b715-2994-4bb8-a908-645515888eea.png)

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
