### PR TITLE
chore(components): add disableOverflow prop to ModalBody

### DIFF
--- a/.changeset/sharp-brooms-run.md
+++ b/.changeset/sharp-brooms-run.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Modal]: Added `disableOverflow` prop to ModalBody so a modal can be used with content that is visible outside the modal body area, i.e. a dropdown.

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -183,6 +183,85 @@ OverflowBodyContent.parameters = {
   chromatic: { delay: 1000, pauseAnimationAtEnd: true },
 };
 
+export const OverflowBodyDisabled = (): React.ReactNode => {
+  const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
+  return (
+    <Box.div h="1000px" w="1350px">
+      <Button onClick={modal.toggle} variant="primary">
+        Open modal
+      </Button>
+      <Modal state={modal}>
+        <ModalHeader>
+          <ModalHeading>This is the heading</ModalHeading>
+          <ModalSubHeading>This is the sub heading</ModalSubHeading>
+        </ModalHeader>
+        <ModalBody disableOverflow>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph marginBottom="space0">
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={modal.toggle} variant="secondary">
+            Back
+          </Button>
+          <Button onClick={modal.toggle} variant="primary">
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box.div>
+  );
+};
+
+OverflowBodyDisabled.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
+};
+
 export const ReallyLongHeader = (): React.ReactNode => {
   const modal = useModalState({ defaultOpen: isChromatic() ? true : false });
   return (

--- a/packages/components/src/components/Modal/ModalBody.tsx
+++ b/packages/components/src/components/Modal/ModalBody.tsx
@@ -7,13 +7,20 @@ export interface ModalBodyProps
   children: NonNullable<React.ReactNode>;
   /** Sets the padding of the modal body. */
   padding?: "space0" | "space60";
+  /** Disables the overflowY for situations where the modal includes a dropdown. */
+  disableOverflow?: boolean;
 }
 
 /** The body content area of the modal. */
 const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
-  ({ children, padding = "space60", ...props }, ref) => {
+  ({ children, disableOverflow, padding = "space60", ...props }, ref) => {
     return (
-      <Box.div overflowY="auto" padding={padding} ref={ref} {...props}>
+      <Box.div
+        overflowY={!disableOverflow ? "auto" : undefined}
+        padding={padding}
+        ref={ref}
+        {...props}
+      >
         {children}
       </Box.div>
     );


### PR DESCRIPTION
## Description of the change

Added the `disableOverflow` prop to ModalBody, so a dropdown can be used inside the modal body area. This is a temporary solution for a product flow that has a multistep modal with a single dropdown as the first step. There is a plan/epic to replace this flow with a different one.

![Screenshot 2022-11-28 at 12 51 47](https://user-images.githubusercontent.com/1350081/204357247-3d83e289-2349-48e0-8232-64db37685aa6.png)

## Testing the change

- [ ] Check out Storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
