### PR TITLE
fix(components): dynamic file restriction texts for Dropzone

### DIFF
--- a/.changeset/fluffy-monkeys-jog.md
+++ b/.changeset/fluffy-monkeys-jog.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Dropzone]: Use `fileTypes` and `maxFileSize` props to generate the file size and type restriction
+text and according error messages.

--- a/packages/components/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.stories.tsx
@@ -17,6 +17,15 @@ const Template: ComponentStory<typeof Dropzone> = (args) => (
 
 export const Default = Template.bind({});
 
+export const WithFileRestrictions = Template.bind({});
+WithFileRestrictions.args = {
+  fileTypes: {
+    "image/jpeg": [".jpg", ".jpeg"],
+    "application/pdf": [".pdf"],
+  },
+  maxFileSize: 12 * 1024 * 1024,
+};
+
 export const Error = Template.bind({});
 Error.args = {
   error: "The document failed to upload",

--- a/packages/components/src/components/Dropzone/Dropzone.test.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.test.tsx
@@ -21,8 +21,31 @@ describe("<Dropzone />", () => {
     expect(
       screen.getByText("Drag and drop or click to select a file")
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText("File must be PDF format and no larger than 50MB")
+      screen.queryByText("File must be PDF format and no larger than 50MB")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders file restriction text", () => {
+    renderDropZone({
+      onCancel: NOOP,
+      onDrop: NOOP,
+      fileTypes: {
+        "image/jpeg": [".jpg", ".jpeg"],
+        "application/pdf": [".pdf"],
+      },
+      maxFileSize: 12 * 1024 * 1024,
+    });
+
+    expect(
+      screen.getByText("Drag and drop or click to select a file")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        "File must be JPG, JPEG, PDF format and no larger than 12MB"
+      )
     ).toBeInTheDocument();
   });
 

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
@@ -1,0 +1,32 @@
+import { getFileRestrictionText } from "./getFileRestrictionText";
+
+describe("getFileRestrictionText", () => {
+  it("returns nothing with no restrictions passed", () => {
+    expect(getFileRestrictionText({})).toBeUndefined();
+  });
+
+  it("returns file size text if passed as parameter", () => {
+    expect(getFileRestrictionText({}, 3 * 1024 * 1024)).toBe(
+      "File must be no larger than 3MB"
+    );
+  });
+
+  it("returns file type text if passed as parameter", () => {
+    expect(getFileRestrictionText({ "image/jpeg": [".jpg"] })).toBe(
+      "File must be JPG format"
+    );
+
+    expect(
+      getFileRestrictionText({
+        "image/jpeg": [".jpg", ".jpeg"],
+        "application/pdf": [".pdf"],
+      })
+    ).toBe("File must be JPG, JPEG, PDF format");
+  });
+
+  it("returns file type and size text if passed as parameter", () => {
+    expect(
+      getFileRestrictionText({ "image/jpeg": [".jpg"] }, 3 * 1024 * 1024)
+    ).toBe("File must be JPG format and no larger than 3MB");
+  });
+});

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.ts
@@ -1,0 +1,32 @@
+import map from "lodash/map";
+import isEmpty from "lodash/isEmpty";
+import compact from "lodash/compact";
+import values from "lodash/values";
+import toUpper from "lodash/toUpper";
+import { FileTypes } from "./Dropzone";
+
+export const fileSizeInMb = (fileSize: number): number =>
+  Math.round(fileSize / 1024 / 1024);
+
+export const getFileExtensions = (fileTypes: FileTypes): string =>
+  map(values(fileTypes).flat(), (extension) =>
+    toUpper(extension.slice(1))
+  ).join(", ");
+
+export const getFileRestrictionText = (
+  fileTypes: FileTypes,
+  maxFileSize?: number
+): string | undefined => {
+  if (isEmpty(fileTypes) && !maxFileSize) {
+    return;
+  }
+
+  const fileExtensions = !isEmpty(fileTypes) && getFileExtensions(fileTypes);
+
+  return compact([
+    "File must be ",
+    fileExtensions && `${fileExtensions} format`,
+    fileExtensions && maxFileSize && " and ",
+    maxFileSize && `no larger than ${fileSizeInMb(maxFileSize)}MB`,
+  ]).join("");
+};


### PR DESCRIPTION
## Description of the change

Use `fileTypes` and `maxFileSize` props to generate the file size and type restriction text and according error messages.

Before this change passing one of the 2 properties had no influence on what was displayed as file size or type restrictions.

Now the dropzone can also be used to upload any file or files of a specific type.

---
![image](https://user-images.githubusercontent.com/6059188/204550730-1295bcb7-38c7-4eb6-b574-3f988bf09481.png)

---

![image](https://user-images.githubusercontent.com/6059188/204550674-f0da2254-cde2-42ff-b697-901553eca732.png)

## Testing the change

- [ ] have a look at the new story `WithFileRestrictions` in storybook


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
