### PR TITLE
feat(design-tokens): add separate js build files

### DIFF
--- a/.changeset/dry-dolphins-jump.md
+++ b/.changeset/dry-dolphins-jump.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Updated the border style values with the new value names.

--- a/.changeset/popular-terms-tease.md
+++ b/.changeset/popular-terms-tease.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/design-tokens": patch
+---
+
+Setup separate build files for javascript and typescript formats. This allows the theme package to import the tokens necessary.

--- a/.changeset/silent-bugs-dress.md
+++ b/.changeset/silent-bugs-dress.md
@@ -1,0 +1,10 @@
+---
+"@localyze-pluto/theme": major
+---
+
+BREAKING CHANGE:
+
+Adds the Pluto design tokens package and imports the necessary tokens into the theme. Doing so changed the names of the Border Style theme values:
+
+- `borderDashed` changed to `borderStyleDashed`
+- `borderSolid` changed to `borderStyleSolid`

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -54,8 +54,10 @@ jobs:
           path: |
             packages/components/**/dist/**/*
             packages/theme/**/dist/**/*
+            packages/design-tokens/**/dist/**/*
             !packages/components/**/node_modules/**/*
             !packages/theme/**/node_modules/**/*
+            !packages/design-tokens/**/node_modules/**/*
 
   type_check:
     name: Type check

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   roots: ["<rootDir>/packages"],
   transform: {
     "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.[j]sx?$": "babel-jest",
   },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   testEnvironment: "jsdom",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-dropzone": "^14.2.3"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.20.2",
     "@changesets/changelog-github": "0.4.7",
     "@changesets/cli": "^2.25.2",
     "@commitlint/cli": "^17.3.0",

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -222,7 +222,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           aria-busy={loading ? "true" : "false"}
           background="none"
           borderRadius="borderRadius20"
-          borderStyle="borderSolid"
+          borderStyle="borderStyleSolid"
           cursor={{
             _: "default",
             hover: "pointer",

--- a/packages/components/src/components/Dropzone/Dropzone.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.tsx
@@ -178,7 +178,7 @@ const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
           )}
           alignItems="center"
           borderRadius="borderRadius30"
-          borderStyle="borderDashed"
+          borderStyle="borderStyleDashed"
           borderWidth="borderWidth10"
           display="flex"
           flexDirection="column"

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -78,7 +78,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
             status === "error" ? "colorBorderError" : "colorBorderWeaker"
           }
           borderRadius="borderRadius30"
-          borderStyle="borderSolid"
+          borderStyle="borderStyleSolid"
           borderWidth="borderWidth10"
           display="flex"
           flexDirection={{ _: "column", md: "row" }}

--- a/packages/components/src/components/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/Icon/Icon.stories.tsx
@@ -41,7 +41,7 @@ export const IconList: React.FC = () => {
         return (
           <Box.div
             borderColor="colorBorder"
-            borderStyle="borderSolid"
+            borderStyle="borderStyleSolid"
             borderWidth="borderWidth10"
             padding="space60"
             textAlign="center"

--- a/packages/components/src/components/InputBox/InputBox.tsx
+++ b/packages/components/src/components/InputBox/InputBox.tsx
@@ -78,7 +78,7 @@ const InputBox = React.forwardRef<HTMLDivElement, InputBoxProps>(
       <Box.div
         alignItems="center"
         borderRadius="borderRadius20"
-        borderStyle="borderSolid"
+        borderStyle="borderStyleSolid"
         color="colorText"
         cursor={disabled ? "not-allowed" : "auto"}
         data-disabled={disabled}

--- a/packages/components/src/components/Modal/ModalFooter.tsx
+++ b/packages/components/src/components/Modal/ModalFooter.tsx
@@ -14,7 +14,7 @@ const ModalFooter = React.forwardRef<HTMLDivElement, ModalFooterProps>(
       <Box.div
         alignItems="center"
         borderTopColor="colorBorderWeakest"
-        borderTopStyle="borderSolid"
+        borderTopStyle="borderStyleSolid"
         borderTopWidth="borderWidth10"
         display="flex"
         gap="space30"

--- a/packages/components/src/components/Modal/ModalHeader.tsx
+++ b/packages/components/src/components/Modal/ModalHeader.tsx
@@ -15,7 +15,7 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
     return (
       <Box.div
         borderBottomColor="colorBorderWeakest"
-        borderBottomStyle="borderSolid"
+        borderBottomStyle="borderStyleSolid"
         borderBottomWidth="borderWidth10"
         display="flex"
         gap="space30"

--- a/packages/components/src/primitives/Box/Box.stories.tsx
+++ b/packages/components/src/primitives/Box/Box.stories.tsx
@@ -12,7 +12,7 @@ export const Default = (): JSX.Element => (
     backgroundColor="colorBackgroundInfo"
     borderColor="colorBorderPrimary"
     borderRadius="borderRadius20"
-    borderStyle="borderSolid"
+    borderStyle="borderStyleSolid"
     borderWidth="borderWidth10"
     color="colorTextStronger"
     padding="space40"

--- a/packages/design-tokens/config.json
+++ b/packages/design-tokens/config.json
@@ -24,7 +24,7 @@
       ]
     },
     "ts": {
-      "transforms": ["name/cti/camel"],
+      "transforms": ["attribute/cti", "name/cti/camel"],
       "transformGroup": "js",
       "buildPath": "dist/js/",
       "files": [
@@ -35,6 +35,204 @@
         {
           "destination": "variables.d.ts",
           "format": "typescript/es6-declarations"
+        },
+        {
+          "destination": "border-radius.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "border-radius"
+            }
+          }
+        },
+        {
+          "destination": "border-radius.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "border-radius"
+            }
+          }
+        },
+        {
+          "destination": "border-style.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "border-style"
+            }
+          }
+        },
+        {
+          "destination": "border-style.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "border-style"
+            }
+          }
+        },
+        {
+          "destination": "border-width.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "border-width"
+            }
+          }
+        },
+        {
+          "destination": "border-width.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "border-width"
+            }
+          }
+        },
+        {
+          "destination": "colors.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "color"
+            }
+          }
+        },
+        {
+          "destination": "colors.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "color"
+            }
+          }
+        },
+        {
+          "destination": "font-family.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "font-family"
+            }
+          }
+        },
+        {
+          "destination": "font-family.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "font-family"
+            }
+          }
+        },
+        {
+          "destination": "font-size.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "font-size"
+            }
+          }
+        },
+        {
+          "destination": "font-size.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "font-size"
+            }
+          }
+        },
+        {
+          "destination": "font-weight.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "font-weight"
+            }
+          }
+        },
+        {
+          "destination": "font-weight.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "font-weight"
+            }
+          }
+        },
+        {
+          "destination": "line-height.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "line-height"
+            }
+          }
+        },
+        {
+          "destination": "line-height.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "line-height"
+            }
+          }
+        },
+        {
+          "destination": "size.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "size"
+            }
+          }
+        },
+        {
+          "destination": "size.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "size"
+            }
+          }
+        },
+        {
+          "destination": "space.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "space"
+            }
+          }
+        },
+        {
+          "destination": "space.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "space"
+            }
+          }
+        },
+        {
+          "destination": "z-index.js",
+          "format": "javascript/es6",
+          "filter": {
+            "attributes": {
+              "category": "z-index"
+            }
+          }
+        },
+        {
+          "destination": "z-index.d.ts",
+          "format": "typescript/es6-declarations",
+          "filter": {
+            "attributes": {
+              "category": "z-index"
+            }
+          }
         }
       ]
     }

--- a/packages/design-tokens/src/tokens/border-style.tokens.json
+++ b/packages/design-tokens/src/tokens/border-style.tokens.json
@@ -1,5 +1,8 @@
 {
   "border-style": {
+    "dashed": {
+      "value": "dashed"
+    },
     "solid": {
       "value": "solid"
     }

--- a/packages/design-tokens/src/tokens/color.tokens.json
+++ b/packages/design-tokens/src/tokens/color.tokens.json
@@ -1,6 +1,7 @@
 {
   "color": {
     "text-strongest": {
+      "type": "color",
       "value": "#0F172A"
     },
     "text-stronger": {
@@ -69,6 +70,12 @@
     "background-primary-strongest": {
       "value": "#041162"
     },
+    "background-decorative-weak": {
+      "value": "#FFF1DB"
+    },
+    "background-decorative-strong": {
+      "value": "#C8F0EF"
+    },
     "background-destructive": {
       "value": "#DC2626"
     },
@@ -92,6 +99,9 @@
     },
     "background-body": {
       "value": "#F7F9FF"
+    },
+    "background-body-strong": {
+      "value": "#1E293B"
     },
     "border-weakest": {
       "value": "#E2E8F0"

--- a/packages/design-tokens/src/tokens/color.tokens.json
+++ b/packages/design-tokens/src/tokens/color.tokens.json
@@ -116,7 +116,7 @@
       "value": "#0F172A"
     },
     "border-error": {
-      "value": "#EF4444"
+      "value": "#DC2626"
     },
     "border-warning": {
       "value": "#D97706"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -28,12 +28,14 @@
     "tsc": "tsc"
   },
   "peerDependencies": {
+    "@localyze-pluto/design-tokens": "^0.0.3",
     "@xstyled/styled-components": "^3.6.0",
     "react": "^17.0.2 || ^18.2.0",
     "react-dom": "^17.0.2 || ^18.2.0",
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
+    "@localyze-pluto/design-tokens": "^0.0.3",
     "@localyze-pluto/eslint-config": "^1.0.1",
     "@localyze-pluto/tsconfig": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -51,7 +51,7 @@ Object {
     "colorBackgroundWeaker": "#F7F9FF",
     "colorBackgroundWeakest": "#F8FAFC",
     "colorBorder": "#64748B",
-    "colorBorderError": "#EF4444",
+    "colorBorderError": "#DC2626",
     "colorBorderPrimary": "#102EE9",
     "colorBorderStrongest": "#0F172A",
     "colorBorderSuccess": "#059669",

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -9,8 +9,8 @@ Object {
     "spin": "x-spin 1s linear infinite",
   },
   "borderStyles": Object {
-    "borderDashed": "dashed",
-    "borderSolid": "solid",
+    "borderStyleDashed": "dashed",
+    "borderStyleSolid": "solid",
   },
   "borderWidths": Object {
     "borderWidth0": "0px",
@@ -51,7 +51,7 @@ Object {
     "colorBackgroundWeaker": "#F7F9FF",
     "colorBackgroundWeakest": "#F8FAFC",
     "colorBorder": "#64748B",
-    "colorBorderError": "#DC2626",
+    "colorBorderError": "#EF4444",
     "colorBorderPrimary": "#102EE9",
     "colorBorderStrongest": "#0F172A",
     "colorBorderSuccess": "#059669",
@@ -106,7 +106,7 @@ Object {
     "fontWeightRegular": "400",
   },
   "fonts": Object {
-    "fontFamilyModerat": "\\"Moderat\\", \\"Inter\\", sans-serif",
+    "fontFamilyModerat": "'Moderat', 'Inter', sans-serif",
   },
   "gridTemplateColumns": Object {
     "1": "repeat(1, minmax(0, 1fr))",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -1,120 +1,47 @@
 import { defaultTheme } from "@xstyled/styled-components";
+import * as borderRadiusTokens from "@localyze-pluto/design-tokens/dist/js/border-radius.js";
+import * as borderStyleTokens from "@localyze-pluto/design-tokens/dist/js/border-style.js";
+import * as borderWidthTokens from "@localyze-pluto/design-tokens/dist/js/border-width.js";
+import * as colorTokens from "@localyze-pluto/design-tokens/dist/js/colors.js";
+import * as fontFamilyTokens from "@localyze-pluto/design-tokens/dist/js/font-family.js";
+import * as fontSizeTokens from "@localyze-pluto/design-tokens/dist/js/font-size.js";
+import * as fontWeightTokens from "@localyze-pluto/design-tokens/dist/js/font-weight.js";
+import * as lineHeightTokens from "@localyze-pluto/design-tokens/dist/js/line-height.js";
+import * as sizeTokens from "@localyze-pluto/design-tokens/dist/js/size.js";
+import * as spaceTokens from "@localyze-pluto/design-tokens/dist/js/space.js";
+import * as zIndexTokens from "@localyze-pluto/design-tokens/dist/js/z-index.js";
 
 export const theme = {
   ...defaultTheme,
   borderStyles: {
-    borderSolid: "solid",
-    borderDashed: "dashed",
+    ...borderStyleTokens,
   },
   borderWidths: {
-    borderWidth0: "0px",
-    borderWidth10: "1px",
-    borderWidth20: "2px",
+    ...borderWidthTokens,
   },
   colors: {
-    colorTextStrongest: "#0F172A",
-    colorTextStronger: "#334155",
-    colorText: "#64748B",
-    colorTextInfo: "#0B1F9C",
-    colorTextError: "#B91C1C",
-    colorTextWarning: "#B45309",
-    colorTextSuccess: "#047857",
-    colorTextInverse: "#FFFFFF",
-    colorTextLink: "#102EE9",
-    colorTextLinkStrong: "#0B1F9C",
-    colorTextLinkVisited: "#950FFF",
-    colorTextHeadingStronger: "#041162",
-    colorTextHeadingStrong: "#102EE9",
-    colorTextHeading: "#334155",
-    colorBackground: "#FFFFFF",
-    colorBackgroundWeakest: "#F8FAFC",
-    colorBackgroundWeaker: "#F7F9FF",
-    colorBackgroundWeak: "#F1F5F9",
-    colorBackgroundStrong: "#CBD5E1",
-    colorBackgroundPrimaryWeak: "#4A63FC",
-    colorBackgroundPrimary: "#102EE9",
-    colorBackgroundPrimaryStrong: "#0B1F9C",
-    colorBackgroundPrimaryStrongest: "#041162",
-    colorBackgroundDecorativeWeak: "#FFF1DB",
-    colorBackgroundDecorativeStrong: "#C8F0EF",
-    colorBackgroundDestructive: "#DC2626",
-    colorBackgroundDestructiveStrong: "#B91C1C",
-    colorBackgroundInfo: "#EBEDFF",
-    colorBackgroundSuccess: "#ECFDF5",
-    colorBackgroundWarning: "#FFFBEB",
-    colorBackgroundError: "#FEF2F2",
-    colorBackgroundLinkVisited: "#F5EEFA",
-    colorBackgroundBody: "#F7F9FF",
-    colorBackgroundBodyStrong: "#1E293B",
+    ...colorTokens,
     colorBackgroundTodo:
       "linear-gradient(360deg, rgba(16, 37, 233, 0.08) 0%, rgba(36, 63, 235, 0.0733333) 49.48%, rgba(255, 255, 255, 0) 100%)",
     colorBackgroundComplete:
       "linear-gradient(360deg, rgba(82, 244, 174, 0.12) 0%, rgba(131, 247, 197, 0.0575) 57.81%, rgba(255, 255, 255, 0) 100%)",
     colorBackgroundPreview:
       "linear-gradient(360deg, rgba(71, 94, 105, 0.08) 6.19%, rgba(71, 94, 105, 0.0504167) 57.3%, rgba(255, 255, 255, 0) 93.81%)",
-    colorBorderWeakest: "#E2E8F0",
-    colorBorderWeaker: "#CBD5E1",
-    colorBorder: "#64748B",
-    colorBorderStrongest: "#0F172A",
-    colorBorderError: "#DC2626",
-    colorBorderWarning: "#D97706",
-    colorBorderSuccess: "#059669",
-    colorBorderPrimary: "#102EE9",
-    colorIconError: "#DC2626",
-    colorIconWarning: "#D97706",
-    colorIconSuccess: "#059669",
-    colorIconInfo: "#102EE9",
-    colorIconWeaker: "#94A3B8",
-    colorIconWeak: "#64748B",
-    colorIconStrong: "#334155",
-    colorIconStronger: "#0F172A",
-    colorAvatarBackgroundBlue: "#B8C2FF",
-    colorAvatarBackgroundGreen: "#8AFECC",
-    colorAvatarBackgroundOrange: "#FBBF24",
-    colorAvatarBackgroundYellow: "#FDE68A",
-    colorAvatarBackgroundLightBlue: "#A9EBE8",
-    colorAvatarBackgroundPink: "#A9EBE8",
   },
   fontSizes: {
-    fontSize10: "0.75rem", // 12px
-    fontSize20: "0.875rem", // 14px
-    fontSize30: "1rem", // 16px
-    fontSize40: "1.25rem", // 20px
-    fontSize50: "1.5rem", // 24px
-    fontSize60: "2rem", // 32px
-    fontSize70: "2.5rem", // 40px
-    fontSize80: "3rem", // 48px
-    fontSize90: "3.375rem", // 54px
+    ...fontSizeTokens,
   },
   fontWeights: {
-    fontWeightLight: "300",
-    fontWeightRegular: "400",
-    fontWeightMedium: "500",
-    fontWeightBold: "700",
+    ...fontWeightTokens,
   },
   fonts: {
-    fontFamilyModerat: '"Moderat", "Inter", sans-serif',
+    ...fontFamilyTokens,
   },
   lineHeights: {
-    lineHeight10: "1rem", // 16px
-    lineHeight20: "1.125rem", // 18px
-    lineHeight30: "1.25rem", // 20px
-    lineHeight40: "1.5rem", // 24px
-    lineHeight50: "1.75rem", // 28px
-    lineHeight60: "2rem", // 32px
-    lineHeight70: "2.5rem", // 40px
-    lineHeight80: "3rem", // 48px
-    lineHeight90: "3.375rem", // 54px
-    lineHeight100: "3.75rem", // 60px
+    ...lineHeightTokens,
   },
   radii: {
-    borderRadius10: "4px",
-    borderRadius20: "6px",
-    borderRadius30: "8px",
-    borderRadius40: "16px",
-    borderRadius50: "24px",
-    borderRadiusCircle: "50%",
-    borderRadiusPill: "100px",
+    ...borderRadiusTokens,
   },
   shadows: {
     shadow: "0px 3px 24px rgba(15, 23, 42, 0.05)",
@@ -123,52 +50,10 @@ export const theme = {
       "0px 1px 2px rgba(0, 0, 0, 0.05), 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 4px #102EE9",
   },
   sizes: {
-    sizeIcon10: "0.75rem", // 12px
-    sizeIcon20: "1rem", // 16px
-    sizeIcon30: "1.25rem", // 20px
-    sizeIcon40: "1.5rem", // 24px
+    ...sizeTokens,
   },
   space: {
-    space0: "0rem", // 0px
-    space10: "0.125rem", // 2px
-    space20: "0.25rem", // 4px
-    space25: "0.4rem", // 6px
-    space30: "0.5rem", // 8px
-    space40: "0.75rem", // 12px
-    space50: "1rem", // 16px
-    space60: "1.25rem", // 20px
-    space70: "1.5rem", // 24px
-    space80: "1.75rem", // 28px
-    space90: "2rem", // 32px
-    space100: "2.25rem", // 36px
-    space110: "2.5rem", // 40px
-    space120: "3rem", // 48px
-    space130: "3.25rem", // 52px
-    space140: "3.5rem", // 56px
-    space150: "3.75rem", // 60px
-    space160: "4.5rem", // 72px
-    space170: "5rem", // 80px
-    space180: "6rem", // 96px
-    space190: "6.25rem", // 100px
-    spaceNegative10: "-0.125rem", // -2px
-    spaceNegative20: "-0.25rem", // -4px
-    spaceNegative30: "-0.5rem", // -8px
-    spaceNegative40: "-0.75rem", // -12px
-    spaceNegative50: "-1rem", // -16px
-    spaceNegative60: "-1.25rem", // -20px
-    spaceNegative70: "-1.5rem", // -24px
-    spaceNegative80: "-1.75rem", // -28px
-    spaceNegative90: "-2rem", // -32px
-    spaceNegative100: "-2.25rem", // -36px
-    spaceNegative110: "-2.5rem", // -40px
-    spaceNegative120: "-3rem", // -48px
-    spaceNegative130: "-3.25rem", // -52px
-    spaceNegative140: "-3.5rem", // -56px
-    spaceNegative150: "-3.75rem", // -60px
-    spaceNegative160: "-4.5rem", // -72px
-    spaceNegative170: "-5rem", // -80px
-    spaceNegative180: "-6rem", // -96px
-    spaceNegative190: "-6.25rem", // -100px
+    ...spaceTokens,
   },
   states: {
     ...defaultTheme.states,
@@ -177,15 +62,6 @@ export const theme = {
     loading: '&[aria-busy="true"]',
   },
   zIndices: {
-    zIndex0: 0,
-    zIndex10: 10,
-    zIndex20: 20,
-    zIndex30: 30,
-    zIndex40: 40,
-    zIndex50: 50,
-    zIndex60: 60,
-    zIndex70: 70,
-    zIndex80: 80,
-    zIndex90: 90,
+    ...zIndexTokens,
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,7 +947,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/preset-env@^7.12.11":
+"@babel/preset-env@^7.12.11", "@babel/preset-env@^7.20.2":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.20.2.tgz#9b1642aa47bb9f43a86f9630011780dab7f86506"
   integrity sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==


### PR DESCRIPTION
## Description of the change

This sets up the use of the Design Tokens package within the Theme package. So now the theme is built using the design tokens. So now if we change a token or add a new one, it will be added to the theme package automatically.

In doing so, there is a change to the border style theme values:

- `borderDashed` changed to `borderStyleDashed`
- `borderSolid` changed to `borderStyleSolid`

## Testing the change

- [ ] Verify all tests pass

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
