### PR TITLE
fix(theme): adjust base styles for app usage

### DIFF
--- a/.changeset/real-mirrors-lay.md
+++ b/.changeset/real-mirrors-lay.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": minor
+---
+
+Removed color from the body base styles so as not to interfere with any downstream application usage.

--- a/.changeset/warm-comics-wonder.md
+++ b/.changeset/warm-comics-wonder.md
@@ -1,0 +1,11 @@
+---
+"@localyze-pluto/components": patch
+---
+
+- [FileUploader]: Set the correct border style prop (borderSolid).
+- [Heading]: Removed the default browser top margin.
+- [InputBox]: Set the correct color prop (colorText).
+- [Label]: Set the correct color prop (colorTextStrongest).
+- [UnorderedList]: Added a color prop (colorTextStrongest | currentColor). Removed the default browser spacing. Added a marginBottom prop (space0 | space70).
+- [OrderedList]: Added a color prop (colorTextStrongest | currentColor). Removed the default browser spacing. Added a marginBottom prop (space0 | space70).
+- [Paragraph]: Set the correct color prop (colorTextStrongest), and removed the default browser top margin.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,7 +12,6 @@ export const decorators = [
   (Story) => {
     return (
       <ThemeProvider theme={theme}>
-        <Preflight />
         <GlobalStyles />
         <BaseStyles />
         <Story />

--- a/packages/components/src/components/Anchor/Anchor.stories.tsx
+++ b/packages/components/src/components/Anchor/Anchor.stories.tsx
@@ -11,7 +11,7 @@ const Template: ComponentStory<typeof Anchor> = (args) => <Anchor {...args} />;
 
 const defaultArgs = {
   children: "I'm an anchor",
-  href: "https://www.localyze.com",
+  href: "#",
 };
 
 export const Default = Template.bind({});

--- a/packages/components/src/components/Avatar/Avatar.tsx
+++ b/packages/components/src/components/Avatar/Avatar.tsx
@@ -122,15 +122,14 @@ const getLabelSizes = (
         fontSize: "fontSize10",
       };
     }
-    case "small":
     case "large": {
       return {
-        fontSize: "fontSize20",
+        fontSize: "fontSize30",
       };
     }
     default: {
       return {
-        fontSize: "fontSize30",
+        fontSize: "fontSize20",
       };
     }
   }

--- a/packages/components/src/components/Callout/Callout.stories.tsx
+++ b/packages/components/src/components/Callout/Callout.stories.tsx
@@ -19,9 +19,9 @@ export const Default = Template.bind({});
 Default.args = {
   children: (
     <Box.div>
-      <Text.p>This is a default message.</Text.p>
+      <Text.span display="block">This is a default message.</Text.span>
       <Box.div color="colorTextLink">
-        <UnorderedList>
+        <UnorderedList color="currentColor" marginBottom="space0">
           <ListItem>
             <Anchor href="https://www.localyze.com">localyze.com</Anchor>
           </ListItem>

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -78,6 +78,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
             status === "error" ? "colorBorderError" : "colorBorderWeaker"
           }
           borderRadius="borderRadius30"
+          borderStyle="borderSolid"
           borderWidth="borderWidth10"
           display="flex"
           flexDirection={{ _: "column", md: "row" }}

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -137,6 +137,7 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
         fontFamily="fontFamilyModerat"
         fontWeight="fontWeightBold"
         marginBottom={marginBottom}
+        marginTop="space0"
         ref={ref}
         {...getHeadingSizes(size)}
         {...props}

--- a/packages/components/src/components/InputBox/InputBox.tsx
+++ b/packages/components/src/components/InputBox/InputBox.tsx
@@ -79,6 +79,7 @@ const InputBox = React.forwardRef<HTMLDivElement, InputBoxProps>(
         alignItems="center"
         borderRadius="borderRadius20"
         borderStyle="borderSolid"
+        color="colorText"
         cursor={disabled ? "not-allowed" : "auto"}
         data-disabled={disabled}
         data-has-error={hasError}

--- a/packages/components/src/components/Label/Label.tsx
+++ b/packages/components/src/components/Label/Label.tsx
@@ -19,7 +19,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
     return (
       <Box.label
         alignItems="center"
-        color="colorText"
+        color="colorTextStrongest"
         display="flex"
         fontFamily="fontFamilyModerat"
         fontSize="fontSize10"

--- a/packages/components/src/components/List/OrderedList.tsx
+++ b/packages/components/src/components/List/OrderedList.tsx
@@ -2,10 +2,17 @@ import styled from "@xstyled/styled-components";
 import React from "react";
 import { Box } from "../../primitives/Box";
 
+type UnOrderedListColorOptions = "colorTextStrongest" | "currentColor";
+type OrderedListMarginOptions = "space0" | "space70";
+
 export interface OrderedListProps
   extends Omit<React.HTMLAttributes<HTMLOListElement>, "color"> {
   /** The list items */
   children: NonNullable<React.ReactNode>;
+  /** The color of the list items */
+  color?: UnOrderedListColorOptions;
+  /** Sets the bottom margin of the ordered list. */
+  marginBottom?: OrderedListMarginOptions;
 }
 
 /** A list of items with bullet points */
@@ -28,9 +35,25 @@ const InnerOrderedList = styled(Box.ol)`
 
 /** A list of numbered items */
 export const OrderedList = React.forwardRef<HTMLOListElement, OrderedListProps>(
-  ({ children, ...props }, ref) => {
+  (
+    {
+      children,
+      color = "colorTextStrongest",
+      marginBottom = "space70",
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <InnerOrderedList ref={ref} {...props}>
+      <InnerOrderedList
+        color={color}
+        listStyleType="none"
+        marginBottom={marginBottom}
+        marginTop="space0"
+        paddingLeft="space0"
+        ref={ref}
+        {...props}
+      >
         {children}
       </InnerOrderedList>
     );

--- a/packages/components/src/components/List/UnorderedList.tsx
+++ b/packages/components/src/components/List/UnorderedList.tsx
@@ -2,10 +2,17 @@ import styled from "@xstyled/styled-components";
 import React from "react";
 import { Box } from "../../primitives/Box";
 
+type UnorderedListColorOptions = "colorTextStrongest" | "currentColor";
+type UnorderedListMarginOptions = "space0" | "space70";
+
 export interface UnorderedListProps
   extends Omit<React.HTMLAttributes<HTMLUListElement>, "color"> {
   /** The list items */
   children: NonNullable<React.ReactNode>;
+  /** The color of the list items */
+  color?: UnorderedListColorOptions;
+  /** Sets the bottom margin of the unordered list. */
+  marginBottom?: UnorderedListMarginOptions;
 }
 
 /** A list of items with bullet points */
@@ -18,7 +25,7 @@ const InnerUnorderedList = styled(Box.ul)`
       content: "•";
       position: absolute;
       font-size: fontSize50;
-      line-height: 0.9rem;
+      line-height: 1rem;
       font-weight: fontWeightBold;
       left: 0;
       top: 0;
@@ -29,12 +36,31 @@ const InnerUnorderedList = styled(Box.ul)`
 export const UnorderedList = React.forwardRef<
   HTMLUListElement,
   UnorderedListProps
->(({ children, ...props }, ref) => {
-  return (
-    <InnerUnorderedList listStylePosition="inside" ref={ref} {...props}>
-      {children}
-    </InnerUnorderedList>
-  );
-});
+>(
+  (
+    {
+      children,
+      color = "colorTextStrongest",
+      marginBottom = "space70",
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <InnerUnorderedList
+        color={color}
+        listStylePosition="inside"
+        listStyleType="none"
+        marginBottom={marginBottom}
+        marginTop="space0"
+        paddingLeft="space0"
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </InnerUnorderedList>
+    );
+  }
+);
 
 UnorderedList.displayName = "UnorderedList";

--- a/packages/components/src/components/Paragraph/Paragraph.tsx
+++ b/packages/components/src/components/Paragraph/Paragraph.tsx
@@ -48,9 +48,11 @@ const Paragraph = React.forwardRef<HTMLParagraphElement, ParagraphProps>(
   ({ children, marginBottom = "space70", size = "medium", ...props }, ref) => {
     return (
       <Text.p
+        color="colorTextStrongest"
         fontFamily="fontFamilyModerat"
         fontWeight="fontWeightRegular"
         marginBottom={marginBottom}
+        marginTop="space0"
         ref={ref}
         {...getParagraphStyles(size)}
         {...props}

--- a/packages/theme/src/styles/base.tsx
+++ b/packages/theme/src/styles/base.tsx
@@ -2,7 +2,6 @@ import { createGlobalStyle } from "@xstyled/styled-components";
 
 export const BaseStyles = createGlobalStyle`
   body {
-    color: colorText;
     font-size: fontSize30;
     font-family: fontFamilyModerat;
     font-weight: fontWeightRegular;


### PR DESCRIPTION
## Description of the change

This is mainly a change to the theme package. After some research I slimmed down the BaseStyles so they can be used in the client app.

This change also corrects the components so they no longer rely on the Preflight so that doesn't need to be used in the client app. You can see a list of changes [here](https://github.com/Localitos/pluto/pull/268/files#diff-44f1f0f54858c7c07832fd685be11e915705c45a4a241e9ae452d92563432139).

## Testing the change

- [ ] Check out storybook

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
