### PR TITLE
fix(components): add isDragActive to reset errors on Dropzone

### DIFF
--- a/.changeset/cuddly-months-fix.md
+++ b/.changeset/cuddly-months-fix.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+fixed dropzone error handling when isDragActive

--- a/packages/components/src/components/Dropzone/Dropzone.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import type { SystemProp, Theme } from "@xstyled/styled-components";
 import map from "lodash/map";
 import { FileWithPath, useDropzone } from "react-dropzone";
@@ -159,6 +159,12 @@ const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
         });
       },
     });
+
+    useEffect(() => {
+      if (isDragActive && !isDragReject) {
+        setDropZoneErrors(undefined);
+      }
+    }, [isDragActive, isDragReject]);
 
     return (
       <>


### PR DESCRIPTION
## Description of the change

The default message was not changing when the a new file was being dragged so we want to reset the errors when the isDragActive is true and the isDragReject is false

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
