### PR TITLE
chore(components): add heading mobile chromatic story

### DIFF
--- a/.changeset/dry-bobcats-doubt.md
+++ b/.changeset/dry-bobcats-doubt.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Heading]: adjusted the breakpoint story so it shows correctly in Chromatic.

--- a/packages/components/src/components/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/Heading/Heading.stories.tsx
@@ -59,6 +59,10 @@ WithBreakpoints.args = {
   size: { _: "heading60", md: "heading10" },
 };
 
+WithBreakpoints.parameters = {
+  chromatic: { viewports: [320, 1200] },
+};
+
 export const NoMargin = Template.bind({});
 NoMargin.args = {
   children: "I'm a h2 element with no bottom margin.",


### PR DESCRIPTION
## Description of the change

Adding mobile viewports to the Heading breakpoint story. These show up in Chromatic snapshots.

## Testing the change

- [ ] Verify new snapshots are in Chromatic

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
