### PR TITLE
fix(components): refactor dropzone to remove isDragReject

### DIFF
--- a/.changeset/yellow-zoos-run.md
+++ b/.changeset/yellow-zoos-run.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Refactor of dropzone to remove isDragReject

--- a/packages/components/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.stories.tsx
@@ -24,6 +24,7 @@ WithFileRestrictions.args = {
     "application/pdf": [".pdf"],
   },
   maxFileSize: 12 * 1024 * 1024,
+  maxNumFiles: 2,
 };
 
 export const Error = Template.bind({});
@@ -67,5 +68,14 @@ export const WithMockedSuccess = (): React.ReactElement => {
     setCancelClick(true);
   };
 
-  return <Dropzone onCancel={onCancel} onDrop={onDrop} progress={progress} />;
+  return (
+    <Dropzone
+      fileTypes={{
+        "application/pdf": [".pdf"],
+      }}
+      onCancel={onCancel}
+      onDrop={onDrop}
+      progress={progress}
+    />
+  );
 };

--- a/packages/components/src/components/Dropzone/Dropzone.test.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.test.tsx
@@ -44,7 +44,7 @@ describe("<Dropzone />", () => {
 
     expect(
       screen.getByText(
-        "File must be JPG, JPEG, PDF format and no larger than 12MB"
+        "File must be JPG, JPEG, PDF format, no larger than 12MB, and you can upload only 1 file."
       )
     ).toBeInTheDocument();
   });

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
@@ -1,32 +1,35 @@
 import { getFileRestrictionText } from "./getFileRestrictionText";
 
 describe("getFileRestrictionText", () => {
-  it("returns nothing with no restrictions passed", () => {
-    expect(getFileRestrictionText({})).toBeUndefined();
-  });
-
   it("returns file size text if passed as parameter", () => {
-    expect(getFileRestrictionText({}, 3 * 1024 * 1024)).toBe(
-      "File must be no larger than 3MB"
+    expect(getFileRestrictionText({}, 1, 3 * 1024 * 1024)).toBe(
+      "File must be no larger than 3MB, and you can upload only 1 file."
     );
   });
 
   it("returns file type text if passed as parameter", () => {
-    expect(getFileRestrictionText({ "image/jpeg": [".jpg"] })).toBe(
-      "File must be JPG format"
+    expect(getFileRestrictionText({ "image/jpeg": [".jpg"] }, 1)).toBe(
+      "File must be JPG format, and you can upload only 1 file."
     );
 
     expect(
-      getFileRestrictionText({
-        "image/jpeg": [".jpg", ".jpeg"],
-        "application/pdf": [".pdf"],
-      })
-    ).toBe("File must be JPG, JPEG, PDF format");
+      getFileRestrictionText(
+        {
+          "image/jpeg": [".jpg", ".jpeg"],
+          "application/pdf": [".pdf"],
+        },
+        1
+      )
+    ).toBe(
+      "File must be JPG, JPEG, PDF format, and you can upload only 1 file."
+    );
   });
 
   it("returns file type and size text if passed as parameter", () => {
     expect(
-      getFileRestrictionText({ "image/jpeg": [".jpg"] }, 3 * 1024 * 1024)
-    ).toBe("File must be JPG format and no larger than 3MB");
+      getFileRestrictionText({ "image/jpeg": [".jpg"] }, 1, 3 * 1024 * 1024)
+    ).toBe(
+      "File must be JPG format, no larger than 3MB, and you can upload only 1 file."
+    );
   });
 });

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.ts
@@ -15,18 +15,24 @@ export const getFileExtensions = (fileTypes: FileTypes): string =>
 
 export const getFileRestrictionText = (
   fileTypes: FileTypes,
+  maxNumFiles: number,
   maxFileSize?: number
 ): string | undefined => {
   if (isEmpty(fileTypes) && !maxFileSize) {
     return;
   }
 
+  const tooManyFilesText = `you can upload only ${maxNumFiles} file${
+    maxNumFiles > 1 ? `s.` : `.`
+  }`;
   const fileExtensions = !isEmpty(fileTypes) && getFileExtensions(fileTypes);
 
   return compact([
     "File must be ",
     fileExtensions && `${fileExtensions} format`,
-    fileExtensions && maxFileSize && " and ",
+    fileExtensions && maxFileSize && ", ",
     maxFileSize && `no larger than ${fileSizeInMb(maxFileSize)}MB`,
+    ", and ",
+    tooManyFilesText,
   ]).join("");
 };


### PR DESCRIPTION
## Description of the change

We removed the isDragReject conditional for error handling. Now the dropzone will only display errors after drop. We also added a maxFiles prop.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
