### PR TITLE
fix(components): refactor dropzone to remove isDragReject

### DIFF
--- a/.changeset/green-snails-kneel.md
+++ b/.changeset/green-snails-kneel.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+adjusted dropzone to exclude hetero file drops

--- a/.changeset/green-snails-kneel.md
+++ b/.changeset/green-snails-kneel.md
@@ -1,5 +1,5 @@
 ---
-"@localyze-pluto/components": minor
+"@localyze-pluto/components": patch
 ---
 
 adjusted dropzone to exclude hetero file drops

--- a/packages/components/src/components/Dropzone/Dropzone.test.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.test.tsx
@@ -44,7 +44,7 @@ describe("<Dropzone />", () => {
 
     expect(
       screen.getByText(
-        "File must be JPG, JPEG, PDF format, no larger than 12MB, and you can upload only 1 file."
+        "You can upload 1 file. File must be JPG, JPEG, PDF format, no larger than 12MB."
       )
     ).toBeInTheDocument();
   });

--- a/packages/components/src/components/Dropzone/Dropzone.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.tsx
@@ -135,11 +135,11 @@ const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
 
     const {
       acceptedFiles,
-      fileRejections,
       getRootProps,
       getInputProps,
       isDragActive,
       isDragAccept,
+      isDragReject,
       isFocused,
     } = useDropzone({
       maxFiles: maxNumFiles,
@@ -149,7 +149,7 @@ const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
         ...fileTypes,
       },
       onDropAccepted: (acceptedFiles) => {
-        if (fileRejections.length === 0) {
+        if (!isDragReject) {
           onDrop(acceptedFiles);
         }
       },

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
@@ -3,13 +3,13 @@ import { getFileRestrictionText } from "./getFileRestrictionText";
 describe("getFileRestrictionText", () => {
   it("returns file size text if passed as parameter", () => {
     expect(getFileRestrictionText({}, 1, 3 * 1024 * 1024)).toBe(
-      "File must be no larger than 3MB, and you can upload only 1 file."
+      "You can upload 1 file. File must be no larger than 3MB."
     );
   });
 
   it("returns file type text if passed as parameter", () => {
     expect(getFileRestrictionText({ "image/jpeg": [".jpg"] }, 1)).toBe(
-      "File must be JPG format, and you can upload only 1 file."
+      "You can upload 1 file. File must be JPG format"
     );
 
     expect(
@@ -20,16 +20,14 @@ describe("getFileRestrictionText", () => {
         },
         1
       )
-    ).toBe(
-      "File must be JPG, JPEG, PDF format, and you can upload only 1 file."
-    );
+    ).toBe("You can upload 1 file. File must be JPG, JPEG, PDF format");
   });
 
   it("returns file type and size text if passed as parameter", () => {
     expect(
       getFileRestrictionText({ "image/jpeg": [".jpg"] }, 1, 3 * 1024 * 1024)
     ).toBe(
-      "File must be JPG format, no larger than 3MB, and you can upload only 1 file."
+      "You can upload 1 file. File must be JPG format, no larger than 3MB."
     );
   });
 });

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.ts
@@ -22,17 +22,16 @@ export const getFileRestrictionText = (
     return;
   }
 
-  const tooManyFilesText = `you can upload only ${maxNumFiles} file${
+  const tooManyFilesText = `You can upload ${maxNumFiles} file${
     maxNumFiles > 1 ? `s.` : `.`
   }`;
   const fileExtensions = !isEmpty(fileTypes) && getFileExtensions(fileTypes);
 
   return compact([
-    "File must be ",
+    tooManyFilesText,
+    " File must be ",
     fileExtensions && `${fileExtensions} format`,
     fileExtensions && maxFileSize && ", ",
-    maxFileSize && `no larger than ${fileSizeInMb(maxFileSize)}MB`,
-    ", and ",
-    tooManyFilesText,
+    maxFileSize && `no larger than ${fileSizeInMb(maxFileSize)}MB.`,
   ]).join("");
 };


### PR DESCRIPTION
## Description of the change

We added the !isDragReject conditional around the onDrop call to prevent the onDrop from being called when there was one file with accepted criteria and one file with rejected criteria.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
