### PR TITLE
fix(components): adjusted file size limit in dropzone to include kb

### DIFF
--- a/.changeset/chatty-stingrays-deliver.md
+++ b/.changeset/chatty-stingrays-deliver.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Adjusted file size limit in dropzone to include kb

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.test.ts
@@ -30,4 +30,12 @@ describe("getFileRestrictionText", () => {
       "You can upload 1 file. File must be JPG format, no larger than 3MB."
     );
   });
+
+  it("returns correct text if file size limit is less than 1mb", () => {
+    expect(
+      getFileRestrictionText({ "image/jpeg": [".jpg"] }, 1, 500 * 1024)
+    ).toBe(
+      "You can upload 1 file. File must be JPG format, no larger than 500KB."
+    );
+  });
 });

--- a/packages/components/src/components/Dropzone/getFileRestrictionText.ts
+++ b/packages/components/src/components/Dropzone/getFileRestrictionText.ts
@@ -5,6 +5,20 @@ import values from "lodash/values";
 import toUpper from "lodash/toUpper";
 import { FileTypes } from "./Dropzone";
 
+const formatBytes = (bytes: number, decimals = 0) => {
+  if (!+bytes) return "0 Bytes";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${Number.parseFloat((bytes / Math.pow(k, i)).toFixed(dm))}${
+    sizes[i]
+  }`;
+};
+
 export const fileSizeInMb = (fileSize: number): number =>
   Math.round(fileSize / 1024 / 1024);
 
@@ -32,6 +46,6 @@ export const getFileRestrictionText = (
     " File must be ",
     fileExtensions && `${fileExtensions} format`,
     fileExtensions && maxFileSize && ", ",
-    maxFileSize && `no larger than ${fileSizeInMb(maxFileSize)}MB.`,
+    maxFileSize && `no larger than ${formatBytes(maxFileSize)}.`,
   ]).join("");
 };


### PR DESCRIPTION
## Description of the change

The dropzone was not including the option for a limit under 1mb so we changed the method to include kb.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
