### PR TITLE
feat(components): add height, color and radius to progress bar

### DIFF
--- a/.changeset/dull-horses-return.md
+++ b/.changeset/dull-horses-return.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Adds support for custom colors, height and border radius on Progress Bar

--- a/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -14,6 +14,22 @@ export const Default = (): JSX.Element => (
   </Box.div>
 );
 
+export const WithHeight = (): JSX.Element => (
+  <Box.div display="flex" flexDirection="column" gap="space40">
+    <ProgressBar borderRadius="borderRadiusPill" h="space50" value={85} />
+  </Box.div>
+);
+
+export const WithCustomColors = (): JSX.Element => (
+  <Box.div display="flex" flexDirection="column" gap="space40">
+    <ProgressBar
+      backgroundColor="colorAvatarBackgroundPink"
+      indicatorColor="colorAvatarBackgroundGreen"
+      value={25}
+    />
+  </Box.div>
+);
+
 export const Animated = (): JSX.Element => {
   const [progress, setProgress] = useState(13);
 

--- a/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
@@ -12,6 +12,25 @@ describe("<ProgressBar />", () => {
     expect(renderedProgressBar).toHaveAttribute("data-value", "50");
   });
 
+  it("renders background color, border radius and height correctly", () => {
+    render(
+      <ProgressBar
+        backgroundColor="colorAvatarBackgroundPink"
+        borderRadius="borderRadiusPill"
+        h="space50"
+        value={25}
+      />
+    );
+
+    const renderedProgressBar = screen.getByRole("progressbar");
+    expect(renderedProgressBar).toHaveAttribute(
+      "background",
+      "colorAvatarBackgroundPink"
+    );
+    expect(renderedProgressBar).toHaveAttribute("h", "space50");
+    expect(renderedProgressBar).toHaveAttribute("radius", "borderRadiusPill");
+  });
+
   it("should allow for global html Attributes", () => {
     render(<ProgressBar aria-label="foo" data-testid="bar" value={100} />);
 

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,11 +1,45 @@
 import React from "react";
 import { styled, theme } from "@localyze-pluto/theme";
 import { Root, Indicator, ProgressProps } from "@radix-ui/react-progress";
+import { SystemProp, Theme } from "@xstyled/styled-components";
+import get from "lodash/get";
+
+export interface ProgressBarProps {
+  /** The progress value. */
+  value: number;
+  /** The height of the progress bar */
+  h?: SystemProp<keyof Theme["space"], Theme>;
+  /** The color of the progress indicator */
+  indicatorColor?: SystemProp<keyof Theme["colors"], Theme>;
+  /** The background color of the progress bar */
+  backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
+  /** The border radius of the progress bar */
+  borderRadius?: SystemProp<keyof Theme["radii"], Theme>;
+}
+
+interface StyledProgressProps extends Omit<ProgressProps, "value"> {
+  value: number;
+  background?: SystemProp<keyof Theme["colors"], Theme>;
+  h?: SystemProp<keyof Theme["space"], Theme>;
+  radius?: SystemProp<keyof Theme["radii"], Theme>;
+}
+
+interface StyledIndicatorProps {
+  background?: SystemProp<keyof Theme["colors"], Theme>;
+  radius?: SystemProp<keyof Theme["radii"], Theme>;
+}
 
 const StyledProgress = styled.div`
-  background-color: ${theme.colors.colorBackgroundWeak};
-  border-radius: ${theme.radii.borderRadius10};
-  height: 6px;
+  background-color: ${(props: StyledProgressProps) =>
+    get(
+      theme.colors,
+      String(props.background),
+      theme.colors.colorBackgroundWeak
+    )};
+  border-radius: ${(props: StyledProgressProps) =>
+    get(theme.radii, String(props.radius), theme.radii.borderRadius10)};
+  height: ${(props: StyledProgressProps) =>
+    get(theme.space, String(props.h), theme.space.space25)};
   overflow: hidden;
   position: relative;
 `;
@@ -14,21 +48,35 @@ const StyledIndicator = styled.div`
   height: 100%;
   width: 100%;
   transition: transform 660ms cubic-bezier(0.65, 0, 0.35, 1);
-  border-radius: ${theme.radii.borderRadius10};
-  background-color: ${theme.colors.colorBackgroundPrimaryWeak};
+  border-radius: ${(props: StyledIndicatorProps) =>
+    get(theme.radii, String(props.radius), theme.radii.borderRadius10)};
+  background-color: ${(props: StyledIndicatorProps) =>
+    get(
+      theme.colors,
+      String(props.background),
+      theme.colors.colorBackgroundPrimaryWeak
+    )};
 `;
-
-export interface ProgressBarProps extends Omit<ProgressProps, "value"> {
-  /** The progress value. */
-  value: number;
-}
 
 /** Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
 const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
-  ({ value, ...props }, ref) => (
-    <StyledProgress as={Root} ref={ref} value={value} {...props}>
+  (
+    { value, h, indicatorColor, backgroundColor, borderRadius, ...props },
+    ref
+  ) => (
+    <StyledProgress
+      as={Root}
+      background={backgroundColor}
+      h={h}
+      radius={borderRadius}
+      ref={ref}
+      value={value}
+      {...props}
+    >
       <StyledIndicator
         as={Indicator}
+        background={indicatorColor}
+        radius={borderRadius}
         style={{ transform: `translateX(-${100 - value}%)` }}
       />
     </StyledProgress>


### PR DESCRIPTION
## Description of the change

Adds `backgroundColor`, `indicatorColor`, height (`h`) and `borderRadius` props to the Progress bar so we can better customize this component when we're using it.

<img width="908" alt="Screenshot 2022-12-09 at 13 40 21" src="https://user-images.githubusercontent.com/55699538/206708345-9a01a0eb-0694-4db1-b207-5895f4a3a69b.png">


## Testing the change

1. Run the Storybook application with `yarn start`
2. Navigate to the Progress Bar tab

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
