### PR TITLE
fix(components): replace progress bar height with size variant

### DIFF
--- a/.changeset/healthy-guests-marry.md
+++ b/.changeset/healthy-guests-marry.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Replace progress bar height with small/large size variant

--- a/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -14,9 +14,9 @@ export const Default = (): JSX.Element => (
   </Box.div>
 );
 
-export const WithHeight = (): JSX.Element => (
+export const Large = (): JSX.Element => (
   <Box.div display="flex" flexDirection="column" gap="space40">
-    <ProgressBar borderRadius="borderRadiusPill" h="space50" value={85} />
+    <ProgressBar size="large" value={90} />
   </Box.div>
 );
 

--- a/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
@@ -7,19 +7,22 @@ describe("<ProgressBar />", () => {
     render(<ProgressBar value={50} />);
 
     const renderedProgressBar = screen.getByRole("progressbar");
-
-    expect(renderedProgressBar).toBeInTheDocument();
     expect(renderedProgressBar).toHaveAttribute("data-value", "50");
+    expect(renderedProgressBar).toHaveAttribute("radius", "borderRadius10");
+    expect(renderedProgressBar).toHaveAttribute("h", "space25");
   });
 
-  it("renders background color, border radius and height correctly", () => {
+  it("renders the large variant correctly", () => {
+    render(<ProgressBar size="large" value={75} />);
+
+    const renderedProgressBar = screen.getByRole("progressbar");
+    expect(renderedProgressBar).toHaveAttribute("h", "space40");
+    expect(renderedProgressBar).toHaveAttribute("radius", "borderRadius50");
+  });
+
+  it("renders background color correctly", () => {
     render(
-      <ProgressBar
-        backgroundColor="colorAvatarBackgroundPink"
-        borderRadius="borderRadiusPill"
-        h="space50"
-        value={25}
-      />
+      <ProgressBar backgroundColor="colorAvatarBackgroundPink" value={25} />
     );
 
     const renderedProgressBar = screen.getByRole("progressbar");
@@ -27,8 +30,6 @@ describe("<ProgressBar />", () => {
       "background",
       "colorAvatarBackgroundPink"
     );
-    expect(renderedProgressBar).toHaveAttribute("h", "space50");
-    expect(renderedProgressBar).toHaveAttribute("radius", "borderRadiusPill");
   });
 
   it("should allow for global html Attributes", () => {

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -4,29 +4,29 @@ import { Root, Indicator, ProgressProps } from "@radix-ui/react-progress";
 import { SystemProp, Theme } from "@xstyled/styled-components";
 import get from "lodash/get";
 
+type ProgressBarSizeOptions = "large" | "small";
+
 export interface ProgressBarProps {
   /** The progress value. */
   value: number;
-  /** The height of the progress bar */
-  h?: SystemProp<keyof Theme["space"], Theme>;
   /** The color of the progress indicator */
   indicatorColor?: SystemProp<keyof Theme["colors"], Theme>;
   /** The background color of the progress bar */
   backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
-  /** The border radius of the progress bar */
-  borderRadius?: SystemProp<keyof Theme["radii"], Theme>;
+  /** Sets the size of the progress bar. */
+  size?: ProgressBarSizeOptions;
 }
 
 interface StyledProgressProps extends Omit<ProgressProps, "value"> {
   value: number;
   background?: SystemProp<keyof Theme["colors"], Theme>;
-  h?: SystemProp<keyof Theme["space"], Theme>;
-  radius?: SystemProp<keyof Theme["radii"], Theme>;
+  h: SystemProp<keyof Theme["space"], Theme>;
+  radius: SystemProp<keyof Theme["radii"], Theme>;
 }
 
 interface StyledIndicatorProps {
   background?: SystemProp<keyof Theme["colors"], Theme>;
-  radius?: SystemProp<keyof Theme["radii"], Theme>;
+  radius: SystemProp<keyof Theme["radii"], Theme>;
 }
 
 const StyledProgress = styled.div`
@@ -37,9 +37,9 @@ const StyledProgress = styled.div`
       theme.colors.colorBackgroundWeak
     )};
   border-radius: ${(props: StyledProgressProps) =>
-    get(theme.radii, String(props.radius), theme.radii.borderRadius10)};
+    get(theme.radii, String(props.radius), "")};
   height: ${(props: StyledProgressProps) =>
-    get(theme.space, String(props.h), theme.space.space25)};
+    get(theme.space, String(props.h), "")};
   overflow: hidden;
   position: relative;
 `;
@@ -49,7 +49,7 @@ const StyledIndicator = styled.div`
   width: 100%;
   transition: transform 660ms cubic-bezier(0.65, 0, 0.35, 1);
   border-radius: ${(props: StyledIndicatorProps) =>
-    get(theme.radii, String(props.radius), theme.radii.borderRadius10)};
+    get(theme.radii, String(props.radius), "")};
   background-color: ${(props: StyledIndicatorProps) =>
     get(
       theme.colors,
@@ -61,26 +61,30 @@ const StyledIndicator = styled.div`
 /** Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
 const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
-    { value, h, indicatorColor, backgroundColor, borderRadius, ...props },
+    { value, size = "small", indicatorColor, backgroundColor, ...props },
     ref
-  ) => (
-    <StyledProgress
-      as={Root}
-      background={backgroundColor}
-      h={h}
-      radius={borderRadius}
-      ref={ref}
-      value={value}
-      {...props}
-    >
-      <StyledIndicator
-        as={Indicator}
-        background={indicatorColor}
+  ) => {
+    const borderRadius = size === "large" ? "borderRadius50" : "borderRadius10";
+
+    return (
+      <StyledProgress
+        as={Root}
+        background={backgroundColor}
+        h={size === "large" ? "space40" : "space25"}
         radius={borderRadius}
-        style={{ transform: `translateX(-${100 - value}%)` }}
-      />
-    </StyledProgress>
-  )
+        ref={ref}
+        value={value}
+        {...props}
+      >
+        <StyledIndicator
+          as={Indicator}
+          background={indicatorColor}
+          radius={borderRadius}
+          style={{ transform: `translateX(-${100 - value}%)` }}
+        />
+      </StyledProgress>
+    );
+  }
 );
 
 ProgressBar.displayName = "ProgressBar";


### PR DESCRIPTION
## Description of the change

By replacing the height of the progress bar with a small/large size variant we simplify the usage of the component and prevent issues at later stages since the developers no longer have to worry about using the right height.

<img width="895" alt="Screenshot 2022-12-09 at 16 56 56" src="https://user-images.githubusercontent.com/55699538/206743228-489fa878-872c-41a3-b460-94cc59b19598.png">


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
