### PR TITLE
fix(design-tokens): export js tokens as one index file

### DIFF
--- a/.changeset/fluffy-fans-kick.md
+++ b/.changeset/fluffy-fans-kick.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/design-tokens": patch
+---
+
+Exporting the js design tokens into one main index file. This should fix import problems when using in other applications.

--- a/.changeset/thick-mangos-smash.md
+++ b/.changeset/thick-mangos-smash.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+Imported the design tokens from the design-tokens main export.

--- a/packages/design-tokens/config.json
+++ b/packages/design-tokens/config.json
@@ -29,14 +29,6 @@
       "buildPath": "dist/js/",
       "files": [
         {
-          "destination": "variables.js",
-          "format": "javascript/es6"
-        },
-        {
-          "destination": "variables.d.ts",
-          "format": "typescript/es6-declarations"
-        },
-        {
           "destination": "border-radius.js",
           "format": "javascript/es6",
           "filter": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -2,8 +2,9 @@
   "name": "@localyze-pluto/design-tokens",
   "version": "0.0.4",
   "description": "Pluto Design System Design Tokens",
-  "main": "./dist/js/variables.js",
-  "types": "./dist/js/variables.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "sideEffects": false,
   "license": "MIT",
   "files": [
@@ -18,7 +19,7 @@
     "directory": "packages/design-tokens"
   },
   "scripts": {
-    "build": "yarn clean && style-dictionary build ",
+    "build": "yarn clean && style-dictionary build && tsup src/index.ts --format esm,cjs --dts --external react --minify",
     "clean": "style-dictionary clean",
     "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "prettier-check": "prettier --check package.json tsconfig.json \"./src/**/*.{tsx,ts,json}\"",

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,11 @@
+export * as BorderRadiusTokens from "../dist/js/border-radius";
+export * as BorderStyleTokens from "../dist/js/border-style";
+export * as BorderWidthTokens from "../dist/js/border-width";
+export * as ColorTokens from "../dist/js/colors";
+export * as FontFamilyTokens from "../dist/js/font-family";
+export * as FontSizeTokens from "../dist/js/font-size";
+export * as FontWeightTokens from "../dist/js/font-weight";
+export * as LineHeightTokens from "../dist/js/line-height";
+export * as SizeTokens from "../dist/js/size";
+export * as SpaceTokens from "../dist/js/space";
+export * as ZIndexTokens from "../dist/js/z-index";

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -1,26 +1,31 @@
+/* The theme object thinks all of the design tokens are typed as any when they're not. */
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { defaultTheme } from "@xstyled/styled-components";
-import * as borderRadiusTokens from "@localyze-pluto/design-tokens/dist/js/border-radius.js";
-import * as borderStyleTokens from "@localyze-pluto/design-tokens/dist/js/border-style.js";
-import * as borderWidthTokens from "@localyze-pluto/design-tokens/dist/js/border-width.js";
-import * as colorTokens from "@localyze-pluto/design-tokens/dist/js/colors.js";
-import * as fontFamilyTokens from "@localyze-pluto/design-tokens/dist/js/font-family.js";
-import * as fontSizeTokens from "@localyze-pluto/design-tokens/dist/js/font-size.js";
-import * as fontWeightTokens from "@localyze-pluto/design-tokens/dist/js/font-weight.js";
-import * as lineHeightTokens from "@localyze-pluto/design-tokens/dist/js/line-height.js";
-import * as sizeTokens from "@localyze-pluto/design-tokens/dist/js/size.js";
-import * as spaceTokens from "@localyze-pluto/design-tokens/dist/js/space.js";
-import * as zIndexTokens from "@localyze-pluto/design-tokens/dist/js/z-index.js";
+import {
+  BorderRadiusTokens,
+  BorderStyleTokens,
+  BorderWidthTokens,
+  ColorTokens,
+  FontFamilyTokens,
+  FontSizeTokens,
+  FontWeightTokens,
+  LineHeightTokens,
+  SizeTokens,
+  SpaceTokens,
+  ZIndexTokens,
+} from "@localyze-pluto/design-tokens";
 
 export const theme = {
   ...defaultTheme,
   borderStyles: {
-    ...borderStyleTokens,
+    ...BorderStyleTokens,
   },
   borderWidths: {
-    ...borderWidthTokens,
+    ...BorderWidthTokens,
   },
   colors: {
-    ...colorTokens,
+    ...ColorTokens,
     colorBackgroundTodo:
       "linear-gradient(360deg, rgba(16, 37, 233, 0.08) 0%, rgba(36, 63, 235, 0.0733333) 49.48%, rgba(255, 255, 255, 0) 100%)",
     colorBackgroundComplete:
@@ -29,19 +34,19 @@ export const theme = {
       "linear-gradient(360deg, rgba(71, 94, 105, 0.08) 6.19%, rgba(71, 94, 105, 0.0504167) 57.3%, rgba(255, 255, 255, 0) 93.81%)",
   },
   fontSizes: {
-    ...fontSizeTokens,
+    ...FontSizeTokens,
   },
   fontWeights: {
-    ...fontWeightTokens,
+    ...FontWeightTokens,
   },
   fonts: {
-    ...fontFamilyTokens,
+    ...FontFamilyTokens,
   },
   lineHeights: {
-    ...lineHeightTokens,
+    ...LineHeightTokens,
   },
   radii: {
-    ...borderRadiusTokens,
+    ...BorderRadiusTokens,
   },
   shadows: {
     shadow: "0px 3px 24px rgba(15, 23, 42, 0.05)",
@@ -50,10 +55,10 @@ export const theme = {
       "0px 1px 2px rgba(0, 0, 0, 0.05), 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 4px #102EE9",
   },
   sizes: {
-    ...sizeTokens,
+    ...SizeTokens,
   },
   space: {
-    ...spaceTokens,
+    ...SpaceTokens,
   },
   states: {
     ...defaultTheme.states,
@@ -62,6 +67,6 @@ export const theme = {
     loading: '&[aria-busy="true"]',
   },
   zIndices: {
-    ...zIndexTokens,
+    ...ZIndexTokens,
   },
 };


### PR DESCRIPTION
## Description of the change

This should fix the downstream teams import errors by not importing a non-compiled js file from the design token package.
- Exports the tokens in on main index file for design-tokens
- Imports the tokens from the main file in the theme

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
