### PR TITLE
feat: [no-issue] add zIndex prop to modal

### DIFF
--- a/.changeset/yellow-lies-heal.md
+++ b/.changeset/yellow-lies-heal.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add zIndex prop to modal

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+import type { SystemProp, Theme } from "@xstyled/styled-components";
 import React from "react";
 import { Dialog } from "ariakit/dialog";
 import type { DialogProps } from "ariakit";
@@ -6,11 +7,13 @@ import { Box } from "../../primitives/Box";
 export interface ModalProps extends Omit<DialogProps, "noonce"> {
   /** The contents of the modal. */
   children: NonNullable<React.ReactNode>;
+  /** The zIndex of the modal. */
+  zIndex?: SystemProp<keyof Theme["zIndices"], Theme>;
 }
 
 /** A Modal is a page overlay that displays information and blocks interaction with the page until an action is taken or the Modal is dismissed. */
 const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
-  ({ children, ...props }, ref) => {
+  ({ children, zIndex = "zIndex30", ...props }, ref) => {
     return (
       <Box.div
         as={Dialog}
@@ -26,7 +29,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         top="50%"
         transform="translate(-50%, -50%)"
         w="90vw"
-        zIndex="zIndex30"
+        zIndex={zIndex}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Description of the change

In Talent-web, the modal was below the other elements in the page for some reason. This is adding the zIndex prop so that we can adjust for the zIndex in the modal.
## Testing the change

I tried to add a story but I couldn't figure out a good way to test this.
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
