### PR TITLE
feat: remove zIndex from modal

### DIFF
--- a/.changeset/strange-cycles-dream.md
+++ b/.changeset/strange-cycles-dream.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Removing the optional zIndex to make it bulletproof

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -1,4 +1,3 @@
-import type { SystemProp, Theme } from "@xstyled/styled-components";
 import React from "react";
 import { Dialog } from "ariakit/dialog";
 import type { DialogProps } from "ariakit";
@@ -7,13 +6,11 @@ import { Box } from "../../primitives/Box";
 export interface ModalProps extends Omit<DialogProps, "noonce"> {
   /** The contents of the modal. */
   children: NonNullable<React.ReactNode>;
-  /** The zIndex of the modal. */
-  zIndex?: SystemProp<keyof Theme["zIndices"], Theme>;
 }
 
 /** A Modal is a page overlay that displays information and blocks interaction with the page until an action is taken or the Modal is dismissed. */
 const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
-  ({ children, zIndex = "zIndex30", ...props }, ref) => {
+  ({ children, ...props }, ref) => {
     return (
       <Box.div
         as={Dialog}
@@ -29,7 +26,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         top="50%"
         transform="translate(-50%, -50%)"
         w="90vw"
-        zIndex={zIndex}
+        zIndex="zIndex30"
         {...props}
       >
         {children}


### PR DESCRIPTION
## Description of the change

We didn't actually end up needing this optional zIndex prop so I am removing it here.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
