### PR TITLE
chore: correct kodiak version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,6 @@ updates:
       time: "04:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 20
-    reviewers:
-      - "localitos/frontend"
+    labels:
+      - "dependencies"
+      - "automerge"

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,8 +1,6 @@
 version = 1
 
 [merge]
-automerge_label = ["🚀 merge it!", "Merge It"]
-blocking_labels = ["WIP", "Do Not Merge"]
 method = "squash"
 
 [merge.automerge_dependencies]
@@ -10,3 +8,6 @@ method = "squash"
 # do not automerge "major" version upgrades.
 versions = ["minor", "patch"]
 usernames = ["dependabot"]
+
+[approve]
+auto_approve_labels = ["dependencies"]

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,4 +1,4 @@
-version = 2
+version = 1
 
 [merge]
 automerge_label = ["🚀 merge it!", "Merge It"]


### PR DESCRIPTION
## Description of the change

Attempting to fix the Kodiak auto-merge config, by using the default settings except for dependabot. This also should auto-approve dependabot patches and minors.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
