### PR TITLE
fix(components): changed dropzone error message handling

### DIFF
--- a/.changeset/silly-comics-knock.md
+++ b/.changeset/silly-comics-knock.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fixed dropzone error message handling

--- a/packages/components/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.stories.tsx
@@ -29,12 +29,12 @@ WithFileRestrictions.args = {
 
 export const Error = Template.bind({});
 Error.args = {
-  error: "The document failed to upload",
+  error: { message: "The document failed to upload" },
 };
 
 export const ErrorWithProgress = Template.bind({});
 ErrorWithProgress.args = {
-  error: "The document failed to upload",
+  error: { message: "The document failed to upload" },
   progress: 50,
 };
 

--- a/packages/components/src/components/Dropzone/Dropzone.test.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.test.tsx
@@ -51,7 +51,7 @@ describe("<Dropzone />", () => {
 
   it("renders error state", () => {
     renderDropZone({
-      error: "File must be less than 50mb.",
+      error: { message: "File must be less than 50mb." },
       onCancel: NOOP,
       onDrop: NOOP,
     });


### PR DESCRIPTION
## Description of the change

The dropzone wasn't handling the errors very well. Because the errors were received only as a string, the error message could have been the same every time. Therefore the error was only displayed the first time an error was passed to the dropzone. We changed the error prop to an object and now the error will update each time. I think @nyan07 can explain WAY better than me.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
