### PR TITLE
fix(components): add missing label to select items

### DIFF
--- a/.changeset/curly-kids-love.md
+++ b/.changeset/curly-kids-love.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Select]: Added a `label` prop to SelectItem. This allows for select items to have a different value and label.

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -16,13 +16,14 @@ export default {
 } as ComponentMeta<typeof Select>;
 
 const selectItems: SelectProps["items"] = [
-  { value: "Select an option", initial: true },
-  { value: "Option One" },
-  { value: "Option Two" },
-  { value: "Option Three", disabled: true },
-  { value: "Option Four" },
+  { value: "select-option", label: "Select an option", initial: true },
+  { value: "option-one", label: "Option One" },
+  { value: "option-two", label: "Option Two" },
+  { value: "option-three", label: "Option Three", disabled: true },
+  { value: "option-four", label: "Option Four" },
   {
-    value:
+    value: "option-five",
+    label:
       "Option Five which is a really long item and should overflow to the next line",
   },
 ];
@@ -150,7 +151,7 @@ export const WithReactHookForm = (): JSX.Element => {
 
   const { control, handleSubmit } = useForm({
     defaultValues: {
-      flavor: "Chocolate",
+      flavor: "chocolate",
     },
   });
 
@@ -171,9 +172,9 @@ export const WithReactHookForm = (): JSX.Element => {
             {...field}
             id={selectID}
             items={[
-              { value: "Chocolate" },
-              { value: "Strawberry" },
-              { value: "Vanilla" },
+              { value: "chocolate", label: "Chocolate" },
+              { value: "strawberry", label: "Strawberry" },
+              { value: "vanilla", label: "Vanilla" },
             ]}
             setValue={field.onChange}
           />

--- a/packages/components/src/components/Select/Select.test.tsx
+++ b/packages/components/src/components/Select/Select.test.tsx
@@ -8,7 +8,10 @@ describe("<Select />", () => {
     required: true,
     disabled: true,
     hasError: true,
-    items: [{ value: "Item One" }, { value: "Item Two" }],
+    items: [
+      { label: "item-one", value: "Item One" },
+      { label: "item-two", value: "Item Two" },
+    ],
   };
 
   render(<Select {...initialProps} />);

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -112,6 +112,9 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       setValue,
     });
 
+    // eslint-disable-next-line lodash/prefer-lodash-method
+    const selectedItem = items.find((item) => item.value === select.value);
+
     return (
       <>
         <Box.button
@@ -161,7 +164,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             w="100%"
             whiteSpace="nowrap"
           >
-            {select.value}
+            {selectedItem?.label}
           </Box.div>
           <Box.div
             display="inline-flex"
@@ -182,6 +185,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
               disabled={item.disabled}
               initial={item.initial}
               key={item.value}
+              label={item.label}
               value={item.value}
             />
           ))}

--- a/packages/components/src/components/Select/SelectItem.tsx
+++ b/packages/components/src/components/Select/SelectItem.tsx
@@ -10,12 +10,14 @@ export interface SelectItemProps
   /** The first item in the set. Can be used as a reset option. */
   initial?: boolean;
   /** The text value of the select item. */
+  label: string;
+  /** The text value of the select item. */
   value: string;
 }
 
 /** A select item is a styled element that can be selected within a select. */
 const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
-  ({ disabled, initial, value, ...props }, ref) => {
+  ({ disabled, initial, label, value, ...props }, ref) => {
     return (
       <Box.div
         as={SelectItemPrimitive}
@@ -46,7 +48,9 @@ const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
         ref={ref}
         value={value}
         {...props}
-      />
+      >
+        {label}
+      </Box.div>
     );
   }
 );

--- a/packages/components/src/components/Select/SelectItem.tsx
+++ b/packages/components/src/components/Select/SelectItem.tsx
@@ -9,7 +9,7 @@ export interface SelectItemProps
   disabled?: boolean;
   /** The first item in the set. Can be used as a reset option. */
   initial?: boolean;
-  /** The text value of the select item. */
+  /** The text label of the select item. */
   label: string;
   /** The text value of the select item. */
   value: string;


### PR DESCRIPTION
## Description of the change

Adds a label prop to SelectItem. This allows select options to have different labels and values, i.e.:

```
{ value: 'USA', text: "United States" }
```

## Testing the change

- [ ] Test in storybook

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
