### PR TITLE
feat(components): added multiselect ability to select

### DIFF
--- a/.changeset/tricky-dots-hide.md
+++ b/.changeset/tricky-dots-hide.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Select]: Adjusted the base functionality so it works as a multiselect. In order to get a multiselect, an array should be passed to either `defaultValue` or `value`.
+
+- Also removed the need for the `initial` prop on `SelectItem` by adding default text if a Select value is an empty string.

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -16,7 +16,6 @@ export default {
 } as ComponentMeta<typeof Select>;
 
 const selectItems: SelectProps["items"] = [
-  { value: "select-option", label: "Select an option", initial: true },
   { value: "option-one", label: "Option One" },
   { value: "option-two", label: "Option Two" },
   { value: "option-three", label: "Option Three", disabled: true },
@@ -28,13 +27,31 @@ const selectItems: SelectProps["items"] = [
   },
 ];
 
+const multiSelectItems: SelectProps["items"] = [
+  { value: "option-one", label: "Option One" },
+  { value: "option-two", label: "Option Two" },
+  { value: "option-three", label: "Option Three" },
+  { value: "option-four", label: "Option Four" },
+];
+
+const flavorItems: SelectProps["items"] = [
+  { value: "chocolate", label: "Chocolate" },
+  { value: "strawberry", label: "Strawberry" },
+  { value: "vanilla", label: "Vanilla" },
+];
+
 export const Default = (): JSX.Element => {
   const selectID = useUID();
   const helpTextID = useUID();
   return (
     <Box.form>
       <Label htmlFor={selectID}>Choose One</Label>
-      <Select id={selectID} items={selectItems} name="select" />
+      <Select
+        aria-describedby={helpTextID}
+        id={selectID}
+        items={selectItems}
+        name="select"
+      />
       <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
     </Box.form>
   );
@@ -46,7 +63,13 @@ export const Large = (): JSX.Element => {
   return (
     <Box.form>
       <Label htmlFor={selectID}>Choose One</Label>
-      <Select id={selectID} items={selectItems} name="select" size="large" />
+      <Select
+        aria-describedby={helpTextID}
+        id={selectID}
+        items={selectItems}
+        name="select"
+        size="large"
+      />
       <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
     </Box.form>
   );
@@ -60,7 +83,13 @@ export const Required = (): JSX.Element => {
       <Label htmlFor={selectID} required>
         Choose One
       </Label>
-      <Select id={selectID} items={selectItems} name="select" required />
+      <Select
+        aria-describedby={helpTextID}
+        id={selectID}
+        items={selectItems}
+        name="select"
+        required
+      />
       <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
     </Box.form>
   );
@@ -72,7 +101,13 @@ export const Disabled = (): JSX.Element => {
   return (
     <Box.form>
       <Label htmlFor={selectID}>Choose One</Label>
-      <Select disabled id={selectID} items={selectItems} name="select" />
+      <Select
+        aria-describedby={helpTextID}
+        disabled
+        id={selectID}
+        items={selectItems}
+        name="select"
+      />
       <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
     </Box.form>
   );
@@ -84,7 +119,13 @@ export const Error = (): JSX.Element => {
   return (
     <Box.form>
       <Label htmlFor={selectID}>Choose One</Label>
-      <Select hasError id={selectID} items={selectItems} name="select" />
+      <Select
+        aria-describedby={helpTextID}
+        hasError
+        id={selectID}
+        items={selectItems}
+        name="select"
+      />
       <HelpText hasError id={helpTextID}>
         This is an error message.
       </HelpText>
@@ -99,7 +140,8 @@ export const LongItem = (): JSX.Element => {
     <Box.form w="250px">
       <Label htmlFor={selectID}>Choose One</Label>
       <Select
-        defaultValue={selectItems[5].value}
+        aria-describedby={helpTextID}
+        defaultValue={selectItems[4].value}
         id={selectID}
         items={selectItems}
         name="select"
@@ -113,10 +155,28 @@ LongItem.parameters = {
   chromatic: { viewports: [320, 1200] },
 };
 
+export const MultiSelect = (): JSX.Element => {
+  const selectID = useUID();
+  const helpTextID = useUID();
+  return (
+    <Box.form>
+      <Label htmlFor={selectID}>Choose One</Label>
+      <Select
+        aria-describedby={helpTextID}
+        defaultValue={[selectItems[0].value, selectItems[1].value]}
+        id={selectID}
+        items={selectItems}
+        name="select"
+      />
+      <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
+    </Box.form>
+  );
+};
+
 export const WithFormik = (): JSX.Element => {
   const formik = useFormik({
     initialValues: {
-      select: selectItems[1].value,
+      select: "",
     },
     onSubmit: (values) => {
       alert(JSON.stringify(values, null, 2));
@@ -128,6 +188,7 @@ export const WithFormik = (): JSX.Element => {
     <Box.form onSubmit={formik.handleSubmit}>
       <Label htmlFor={selectID}>Choose One</Label>
       <Select
+        aria-describedby={helpTextID}
         id={selectID}
         items={selectItems}
         name="select"
@@ -144,6 +205,72 @@ export const WithFormik = (): JSX.Element => {
   );
 };
 
+export const MultiSelectWithFormik = (): JSX.Element => {
+  const formik = useFormik({
+    initialValues: {
+      select: [],
+      selectTwo: [multiSelectItems[1].value],
+      selectThree: [multiSelectItems[1].value, multiSelectItems[2].value],
+    },
+    onSubmit: (values) => {
+      alert(JSON.stringify(values, null, 2));
+    },
+  });
+  const selectID = useUID();
+  const selectIDTwo = useUID();
+  const selectIDThree = useUID();
+  const helpTextID = useUID();
+  const helpTextIDTwo = useUID();
+  const helpTextIDThree = useUID();
+  return (
+    <Box.form onSubmit={formik.handleSubmit}>
+      <Box.div marginBottom="space70">
+        <Label htmlFor={selectID}>Choose One</Label>
+        <Select
+          aria-describedby={helpTextID}
+          id={selectID}
+          items={multiSelectItems}
+          name="select"
+          setValue={(value) => formik.setFieldValue("select", value)}
+          value={formik.values.select}
+        />
+        <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
+      </Box.div>
+      <Box.div marginBottom="space70">
+        <Label htmlFor={selectIDTwo}>Choose One</Label>
+        <Select
+          aria-describedby={helpTextIDTwo}
+          id={selectIDTwo}
+          items={multiSelectItems}
+          name="selectTwo"
+          setValue={(value) => formik.setFieldValue("selectTwo", value)}
+          value={formik.values.selectTwo}
+        />
+        <HelpText id={helpTextIDTwo}>Please choose one of the values.</HelpText>
+      </Box.div>
+      <Box.div marginBottom="space70">
+        <Label htmlFor={selectIDThree}>Choose One</Label>
+        <Select
+          aria-describedby={helpTextIDThree}
+          id={selectIDThree}
+          items={multiSelectItems}
+          name="selectThree"
+          setValue={(value) => formik.setFieldValue("selectThree", value)}
+          value={formik.values.selectThree}
+        />
+        <HelpText id={helpTextIDThree}>
+          Please choose one of the values.
+        </HelpText>
+      </Box.div>
+      <Box.div marginTop="space70">
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </Box.form>
+  );
+};
+
 export const WithReactHookForm = (): JSX.Element => {
   interface FormInputs {
     flavor: string;
@@ -151,7 +278,7 @@ export const WithReactHookForm = (): JSX.Element => {
 
   const { control, handleSubmit } = useForm({
     defaultValues: {
-      flavor: "chocolate",
+      flavor: "",
     },
   });
 
@@ -170,17 +297,105 @@ export const WithReactHookForm = (): JSX.Element => {
         render={({ field }) => (
           <Select
             {...field}
+            aria-describedby={helpTextID}
             id={selectID}
-            items={[
-              { value: "chocolate", label: "Chocolate" },
-              { value: "strawberry", label: "Strawberry" },
-              { value: "vanilla", label: "Vanilla" },
-            ]}
+            items={flavorItems}
             setValue={field.onChange}
           />
         )}
       />
       <HelpText id={helpTextID}>Please choose one of the flavors.</HelpText>
+      <Box.div marginTop="space70">
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </Box.form>
+  );
+};
+
+export const MultiSelectWithReactHookForm = (): JSX.Element => {
+  interface FormInputs {
+    flavor: string[];
+    flavorTwo: string[];
+    flavorThree: string[];
+  }
+
+  const { control, handleSubmit } = useForm({
+    defaultValues: {
+      flavor: [],
+      flavorTwo: [flavorItems[0].value],
+      flavorThree: [flavorItems[0].value, flavorItems[2].value],
+    },
+  });
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const onSubmit: SubmitHandler<FormInputs> = (data) =>
+    alert(JSON.stringify(data, null, 2));
+
+  const selectID = useUID();
+  const selectIDTwo = useUID();
+  const selectIDThree = useUID();
+  const helpTextID = useUID();
+  const helpTextIDTwo = useUID();
+  const helpTextIDThree = useUID();
+  return (
+    <Box.form onSubmit={handleSubmit(onSubmit)}>
+      <Box.div marginBottom="space70">
+        <Label htmlFor={selectID}>Choose a flavor</Label>
+        <Controller
+          control={control}
+          name="flavor"
+          render={({ field }) => (
+            <Select
+              {...field}
+              aria-describedby={helpTextID}
+              id={selectID}
+              items={flavorItems}
+              setValue={field.onChange}
+            />
+          )}
+        />
+        <HelpText id={helpTextID}>Please choose one of the flavors.</HelpText>
+      </Box.div>
+      <Box.div marginBottom="space70">
+        <Label htmlFor={selectIDTwo}>Choose a flavor</Label>
+        <Controller
+          control={control}
+          name="flavorTwo"
+          render={({ field }) => (
+            <Select
+              {...field}
+              aria-describedby={helpTextIDTwo}
+              id={selectIDTwo}
+              items={flavorItems}
+              setValue={field.onChange}
+            />
+          )}
+        />
+        <HelpText id={helpTextIDTwo}>
+          Please choose one of the flavors.
+        </HelpText>
+      </Box.div>
+      <Box.div marginBottom="space70">
+        <Label htmlFor={selectIDThree}>Choose a flavor</Label>
+        <Controller
+          control={control}
+          name="flavorThree"
+          render={({ field }) => (
+            <Select
+              {...field}
+              aria-describedby={helpTextIDThree}
+              id={selectIDThree}
+              items={flavorItems}
+              setValue={field.onChange}
+            />
+          )}
+        />
+        <HelpText id={helpTextIDThree}>
+          Please choose one of the flavors.
+        </HelpText>
+      </Box.div>
       <Box.div marginTop="space70">
         <Button type="submit" variant="primary">
           Submit

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -155,6 +155,25 @@ LongItem.parameters = {
   chromatic: { viewports: [320, 1200] },
 };
 
+export const Placeholder = (): JSX.Element => {
+  const selectID = useUID();
+  const helpTextID = useUID();
+  return (
+    <Box.form>
+      <Label htmlFor={selectID}>Choose One</Label>
+      <Select
+        aria-describedby={helpTextID}
+        defaultValue=""
+        id={selectID}
+        items={selectItems}
+        name="select"
+        placeholder="This is a custom placeholder"
+      />
+      <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
+    </Box.form>
+  );
+};
+
 export const MultiSelect = (): JSX.Element => {
   const selectID = useUID();
   const helpTextID = useUID();

--- a/packages/components/src/components/Select/Select.test.tsx
+++ b/packages/components/src/components/Select/Select.test.tsx
@@ -9,28 +9,53 @@ describe("<Select />", () => {
     disabled: true,
     hasError: true,
     items: [
-      { label: "item-one", value: "Item One" },
-      { label: "item-two", value: "Item Two" },
+      { value: "item-one", label: "Item One" },
+      { value: "item-two", label: "Item Two" },
     ],
+    value: "",
   };
 
-  render(<Select {...initialProps} />);
-
-  const SelectElement = screen.getByRole("combobox");
-
   it("renders correctly", () => {
+    render(<Select {...initialProps} />);
+    const SelectElement = screen.getByRole("combobox");
     expect(SelectElement).toBeInTheDocument();
+    expect(screen.getByText("Select one")).toBeInTheDocument();
+  });
+
+  it("should render a selection", () => {
+    render(<Select {...initialProps} value={initialProps.items[0].value} />);
+    const SelectElement = screen.getByRole("combobox");
+    expect(SelectElement).toBeInTheDocument();
+    expect(screen.getAllByText("Item One")[0]).toBeInTheDocument();
+  });
+
+  it("should render a multiselection", () => {
+    render(
+      <Select
+        {...initialProps}
+        value={[initialProps.items[0].value, initialProps.items[1].value]}
+      />
+    );
+    const SelectElement = screen.getByRole("combobox");
+    expect(SelectElement).toBeInTheDocument();
+    expect(screen.getByText("Item One, Item Two")).toBeInTheDocument();
   });
 
   it("should render a required select", () => {
-    expect(SelectElement).toHaveAttribute("aria-required", "true");
+    render(<Select {...initialProps} />);
+    const SelectElement = screen.getByRole("combobox");
+    expect(SelectElement).toBeRequired();
   });
 
   it("should render a disabled select", () => {
-    expect(SelectElement).toHaveAttribute("disabled", "");
+    render(<Select {...initialProps} />);
+    const SelectElement = screen.getByRole("combobox");
+    expect(SelectElement).toBeDisabled();
   });
 
   it("should render a select id", () => {
+    render(<Select {...initialProps} />);
+    const SelectElement = screen.getByRole("combobox");
     expect(SelectElement).toHaveAttribute("id", "select");
   });
 });

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -49,6 +49,8 @@ export interface SelectProps
   items: SelectItemProps[];
   /** The `name` of the select. */
   name?: string;
+  /** The text to be used for the select placeholder. */
+  placeholder?: string;
   /** Sets the select state to required, so a user has to provide a value in order to be valid. */
   required?: boolean;
   /** Function that will be called when setting the select value state. */
@@ -92,14 +94,23 @@ const getSelectStyles = (
 
 const getSelectedLabel = (
   items: SelectItemProps[],
-  value: string[] | string
+  value: string[] | string,
+  placeholder?: string
 ) => {
   if (value === "") {
-    return <Text.span color="colorText">{NO_SELECTION_STRING}</Text.span>;
+    return (
+      <Text.span color="colorText">
+        {placeholder || NO_SELECTION_STRING}
+      </Text.span>
+    );
   }
   if (isArray(value)) {
     if (value.length === 0)
-      return <Text.span color="colorText">{NO_SELECTION_STRING}</Text.span>;
+      return (
+        <Text.span color="colorText">
+          {placeholder || NO_SELECTION_STRING}
+        </Text.span>
+      );
     if (value.length === 1)
       // eslint-disable-next-line lodash/prefer-lodash-method
       return items.find((item) => item.value === value[0])?.label;
@@ -122,6 +133,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       id,
       items,
       name,
+      placeholder,
       required,
       setValue,
       size = "small",
@@ -188,7 +200,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             w="100%"
             whiteSpace="nowrap"
           >
-            {getSelectedLabel(items, select.value)}
+            {getSelectedLabel(items, select.value, placeholder)}
           </Box.div>
           <Box.div
             display="inline-flex"

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -9,11 +9,15 @@ import {
 } from "ariakit/select";
 import type { SelectProps as SelectPrimitiveProps } from "ariakit/select";
 import type { SystemProp, Theme } from "@xstyled/styled-components";
+import isArray from "lodash/isArray";
 import { Box } from "../../primitives/Box";
+import { Text } from "../../primitives/Text";
 import { Icon } from "../Icon";
 import { SelectItem } from "./SelectItem";
 import type { SelectItemProps } from "./SelectItem";
 import { SelectPopover } from "./SelectPopover";
+
+const NO_SELECTION_STRING = "Select one";
 
 export interface SelectProps
   extends Omit<
@@ -34,7 +38,7 @@ export interface SelectProps
     | "wrapElement"
   > {
   /** The default selected option of the select. */
-  defaultValue?: string;
+  defaultValue?: string[] | string;
   /** Sets the state of the select to disabled, so a user is not able to interact with it. */
   disabled?: boolean;
   /** Sets the state of the select to an error state. */
@@ -52,7 +56,7 @@ export interface SelectProps
   /** Changes the size of the select. */
   size?: "large" | "small";
   /** The selected option of the select. */
-  value?: string;
+  value?: string[] | string;
 }
 
 const getSelectStyles = (
@@ -86,6 +90,28 @@ const getSelectStyles = (
   };
 };
 
+const getSelectedLabel = (
+  items: SelectItemProps[],
+  value: string[] | string
+) => {
+  if (value === "") {
+    return <Text.span color="colorText">{NO_SELECTION_STRING}</Text.span>;
+  }
+  if (isArray(value)) {
+    if (value.length === 0)
+      return <Text.span color="colorText">{NO_SELECTION_STRING}</Text.span>;
+    if (value.length === 1)
+      // eslint-disable-next-line lodash/prefer-lodash-method
+      return items.find((item) => item.value === value[0])?.label;
+    return map(value, (val) => {
+      // eslint-disable-next-line lodash/prefer-lodash-method
+      return items.find((item) => item.value === val)?.label;
+    }).join(", ") as string;
+  }
+  // eslint-disable-next-line lodash/prefer-lodash-method
+  return items.find((item) => item.value === value)?.label;
+};
+
 /** A select is an styled form element that allows users to select a value from a list. */
 const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
   (
@@ -112,9 +138,6 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       setValue,
     });
 
-    // eslint-disable-next-line lodash/prefer-lodash-method
-    const selectedItem = items.find((item) => item.value === select.value);
-
     return (
       <>
         <Box.button
@@ -127,7 +150,8 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           borderStyle="borderStyleSolid"
           borderWidth="borderWidth10"
           color={
-            disabled || startsWith(select.value, "select-")
+            disabled ||
+            (!isArray(select.value) && startsWith(select.value, "select-"))
               ? "colorText"
               : "colorTextStronger"
           }
@@ -164,7 +188,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             w="100%"
             whiteSpace="nowrap"
           >
-            {selectedItem?.label}
+            {getSelectedLabel(items, select.value)}
           </Box.div>
           <Box.div
             display="inline-flex"
@@ -183,7 +207,6 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           {map(items, (item) => (
             <SelectItem
               disabled={item.disabled}
-              initial={item.initial}
               key={item.value}
               label={item.label}
               value={item.value}

--- a/packages/components/src/components/Select/SelectItem.tsx
+++ b/packages/components/src/components/Select/SelectItem.tsx
@@ -7,8 +7,6 @@ export interface SelectItemProps
   extends Omit<SelectItemPrimitiveProps, "nonce"> {
   /** Sets the state of the select item to disabled. */
   disabled?: boolean;
-  /** The first item in the set. Can be used as a reset option. */
-  initial?: boolean;
   /** The text label of the select item. */
   label: string;
   /** The text value of the select item. */
@@ -17,30 +15,29 @@ export interface SelectItemProps
 
 /** A select item is a styled element that can be selected within a select. */
 const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
-  ({ disabled, initial, label, value, ...props }, ref) => {
+  ({ disabled, label, value, ...props }, ref) => {
     return (
       <Box.div
         as={SelectItemPrimitive}
         backgroundColor={{
           activeItem: "colorBackgroundWeak",
-          selected: {
-            _: initial ? "colorBackground" : "colorBackgroundInfo",
-            activeItem: "colorBackgroundWeak",
-          },
+          selected: "colorBackgroundInfo",
         }}
         borderLeftColor={{
           _: "colorBackground",
           activeItem: "colorBackgroundWeak",
-          selected: initial ? "colorBackground" : "colorBorderPrimary",
+          selected: "colorBorderPrimary",
         }}
         borderLeftStyle="borderStyleSolid"
         borderLeftWidth="borderWidth20"
-        color={disabled || initial ? "colorText" : "colorTextStrongest"}
+        color={disabled ? "colorText" : "colorTextStrongest"}
         cursor="default"
         disabled={disabled}
         fontFamily="fontFamilyModerat"
         fontSize="fontSize20"
         fontWeight="fontWeightMedium"
+        marginBottom="space10"
+        marginTop="space10"
         paddingBottom="space30"
         paddingLeft="space50"
         paddingRight="space50"


### PR DESCRIPTION
## Description of the change

Adjusted the base functionality so it works as a multiselect. In order to get a multiselect, an array should be passed to either `defaultValue` or `value`.

- Also removed the need for the `initial` prop on `SelectItem` by adding default text if a Select value is an empty string.!
 
![Screenshot 2022-12-16 at 15 21 20](https://user-images.githubusercontent.com/1350081/208191346-56b5eb7f-4c88-4b83-9b86-1c621d58288e.png)


## Testing the change

- [ ] Load storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
