### PR TITLE
feat(components): added useToast hook and ToastContainer

### DIFF
--- a/.changeset/poor-buttons-joke.md
+++ b/.changeset/poor-buttons-joke.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Toast]: Added useToast, ToastContext, and ToastContainer so teams have the option to fire toasts using a hook.

--- a/packages/components/src/components/Toast/Toast.stories.tsx
+++ b/packages/components/src/components/Toast/Toast.stories.tsx
@@ -3,8 +3,12 @@ import React from "react";
 import isChromatic from "chromatic/isChromatic";
 import { Anchor } from "../Anchor";
 import { Button } from "../Button";
+import { Box } from "../../primitives/Box";
 import { Toast } from "./Toast";
 import { ToastViewport } from "./ToastViewport";
+import { useToast } from "./useToast";
+import { ToastContainer } from "./ToastContainer";
+import type { ToastCtaProps } from "./types";
 import { ToastProvider } from ".";
 
 export default {
@@ -63,3 +67,35 @@ MultiLineContent.args = {
   children:
     "Reports have been successfully sent to recipients! This should wrap to a second line.",
 };
+
+const SampleApp = (): JSX.Element => {
+  const toast = useToast();
+
+  const ctaAction: ToastCtaProps = {
+    content: <Anchor href="#">See link here.</Anchor>,
+    altText: "See link here.",
+  };
+
+  return (
+    <Box.div display="flex" gap="space70">
+      <Button
+        onClick={() => toast("Toast message!", "success")}
+        variant="primary"
+      >
+        Open Toast
+      </Button>
+      <Button
+        onClick={() => toast("Toast message!", "error", "action-id", ctaAction)}
+        variant="primary"
+      >
+        Open Toast with action
+      </Button>
+    </Box.div>
+  );
+};
+
+export const WithToastContainer = (): JSX.Element => (
+  <ToastContainer>
+    <SampleApp />
+  </ToastContainer>
+);

--- a/packages/components/src/components/Toast/Toast.test.tsx
+++ b/packages/components/src/components/Toast/Toast.test.tsx
@@ -1,7 +1,23 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import { Button } from "../Button";
 import { Default } from "./Toast.stories";
+import { useToast } from "./useToast";
+import { ToastContainer } from "./ToastContainer";
+
+const SampleApp = (): JSX.Element => {
+  const toast = useToast();
+
+  return (
+    <Button
+      onClick={() => toast("Toast message!", "success")}
+      variant="primary"
+    >
+      Open Toast
+    </Button>
+  );
+};
 
 describe("<Toast />", () => {
   it("should open and close a toast", async () => {
@@ -21,5 +37,22 @@ describe("<Toast />", () => {
     await waitFor(() => expect(renderedToast).not.toBeInTheDocument(), {
       timeout: 1000,
     });
+  });
+});
+
+describe("<ToastContainer />", () => {
+  it("should open a toast in the ToastContainer", async () => {
+    render(
+      <ToastContainer>
+        <SampleApp />
+      </ToastContainer>
+    );
+
+    const renderedOpenButton = screen.getByRole("button");
+    await userEvent.click(renderedOpenButton);
+
+    const renderedToast = screen.getByText("Toast message!");
+    expect(screen.getByRole("region")).toBeInTheDocument();
+    expect(renderedToast).toBeInTheDocument();
   });
 });

--- a/packages/components/src/components/Toast/Toast.tsx
+++ b/packages/components/src/components/Toast/Toast.tsx
@@ -3,24 +3,7 @@ import * as ToastPrimitive from "@radix-ui/react-toast";
 import { Box } from "../../primitives/Box";
 import { Text } from "../../primitives/Text";
 import { Icon } from "../Icon";
-import type { ToastVariants } from "./types";
-
-export interface ToastCtaProps {
-  /** The content of the action. */
-  content: React.ReactNode;
-  /** The accessible alt text used if an action is used in the toast. */
-  altText: string;
-}
-
-export interface ToastProps
-  extends Omit<React.ComponentProps<typeof ToastPrimitive.Root>, "asChild"> {
-  /** The text content of the toast. */
-  children: NonNullable<React.ReactNode>;
-  /** The type and style of the toast. */
-  variant: ToastVariants;
-  /** An action that users can take, but also may be safely ignored. */
-  cta?: ToastCtaProps;
-}
+import type { ToastProps } from "./types";
 
 /** A succinct message that is displayed temporarily. */
 const Toast = React.forwardRef<HTMLLIElement, ToastProps>(

--- a/packages/components/src/components/Toast/ToastContainer.tsx
+++ b/packages/components/src/components/Toast/ToastContainer.tsx
@@ -1,0 +1,51 @@
+import uniqueId from "lodash/uniqueId";
+import map from "lodash/map";
+import React from "react";
+import { ToastViewport } from "./ToastViewport";
+import type {
+  ToastContainerProps,
+  ToastStateProps,
+  ToastVariants,
+  ToastCtaProps,
+} from "./types";
+import { Toast } from "./Toast";
+import { ToastContext } from "./ToastContext";
+import { ToastProvider } from "./index";
+
+const ToastContainer = ({
+  children,
+}: ToastContainerProps): React.ReactElement => {
+  const [toasts, setToasts] = React.useState<ToastStateProps[]>([]);
+
+  return (
+    <ToastContext.Provider
+      value={{
+        toast: (
+          message: string,
+          variant: ToastVariants = "success",
+          id,
+          cta?: ToastCtaProps
+        ) =>
+          setToasts([
+            ...toasts,
+            { message, variant, id: uniqueId(`pluto-toast-${id}-`), cta },
+          ]),
+      }}
+    >
+      <ToastProvider>
+        {children}
+
+        {map(toasts, (toast) => (
+          <Toast cta={toast.cta} key={toast.id} variant={toast.variant}>
+            {toast.message}
+          </Toast>
+        ))}
+        <ToastViewport />
+      </ToastProvider>
+    </ToastContext.Provider>
+  );
+};
+
+ToastContainer.displayName = "ToastContainer";
+
+export { ToastContainer };

--- a/packages/components/src/components/Toast/ToastContext.tsx
+++ b/packages/components/src/components/Toast/ToastContext.tsx
@@ -1,0 +1,7 @@
+import noop from "lodash/noop";
+import { createContext } from "react";
+import type { ToastContextProps } from "./types";
+
+export const ToastContext = createContext<ToastContextProps>({
+  toast: noop,
+});

--- a/packages/components/src/components/Toast/ToastViewport.tsx
+++ b/packages/components/src/components/Toast/ToastViewport.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import * as ToastPrimitive from "@radix-ui/react-toast";
 import { Box } from "../../primitives/Box";
-
-export type ToastViewportProps = ToastPrimitive.ToastViewportProps;
+import type { ToastViewportProps } from "./types";
 
 /** The fixed area where toasts appear. */
 const ToastViewport = React.forwardRef<HTMLOListElement, ToastViewportProps>(

--- a/packages/components/src/components/Toast/index.ts
+++ b/packages/components/src/components/Toast/index.ts
@@ -3,4 +3,7 @@ import * as ToastPrimitive from "@radix-ui/react-toast";
 export const ToastProvider = ToastPrimitive.Provider;
 export * from "./Toast";
 export * from "./ToastViewport";
+export * from "./ToastContext";
+export * from "./ToastContainer";
+export * from "./useToast";
 export * from "./types";

--- a/packages/components/src/components/Toast/types.ts
+++ b/packages/components/src/components/Toast/types.ts
@@ -1,1 +1,48 @@
+import * as ToastPrimitive from "@radix-ui/react-toast";
+
 export type ToastVariants = "error" | "success";
+
+export interface ToastCtaProps {
+  /** The content of the action. */
+  content: React.ReactNode;
+  /** The accessible alt text used if an action is used in the toast. */
+  altText: string;
+}
+
+export interface ToastProps
+  extends Omit<React.ComponentProps<typeof ToastPrimitive.Root>, "asChild"> {
+  /** The text content of the toast. */
+  children: NonNullable<React.ReactNode>;
+  /** The type and style of the toast. */
+  variant: ToastVariants;
+  /** An action that users can take, but also may be safely ignored. */
+  cta?: ToastCtaProps;
+}
+
+export interface ToastStateProps {
+  /** The text content of the toast. */
+  message: string;
+  /** The type and style of the toast. */
+  variant: ToastVariants;
+  /** A unique id passed to the toast. */
+  id?: string;
+  /** An action that users can take, but also may be safely ignored. */
+  cta?: ToastCtaProps;
+}
+
+export interface ToastContainerProps {
+  /** The valid contents of the ToastContainer */
+  children: NonNullable<React.ReactNode>;
+}
+
+export interface ToastContextProps {
+  /** ToastStateProps */
+  toast: (
+    message: string,
+    variant: ToastVariants,
+    id?: string,
+    cta?: ToastCtaProps
+  ) => void;
+}
+
+export type ToastViewportProps = ToastPrimitive.ToastViewportProps;

--- a/packages/components/src/components/Toast/useToast.tsx
+++ b/packages/components/src/components/Toast/useToast.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { ToastContext } from "./ToastContext";
+import type { ToastContextProps } from "./types";
+
+export const useToast = (): ToastContextProps["toast"] => {
+  const { toast } = React.useContext(ToastContext);
+  return toast;
+};


### PR DESCRIPTION
## Description of the change

Added a `useToast` hook and `ToastContainer` component that can be added to downstream applications and will make firing toasts a simpler process, and will require much less code duplication. 

Thanks @nyan07 for the inspiration!

![Screenshot 2022-12-21 at 10 57 27](https://user-images.githubusercontent.com/1350081/208962065-195cf1ed-dde7-4e98-97f6-81f91deec9a5.png)

## Testing the change

- [ ] Fire up storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
