### PR TITLE
feat: add borderRadius0 token

### DIFF
--- a/.changeset/sour-insects-sneeze.md
+++ b/.changeset/sour-insects-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/design-tokens": patch
+"@localyze-pluto/theme": patch
+---
+
+Add new borderRadius tokens

--- a/packages/design-tokens/src/tokens/border-radius.tokens.json
+++ b/packages/design-tokens/src/tokens/border-radius.tokens.json
@@ -1,5 +1,8 @@
 {
   "border-radius": {
+    "0": {
+      "value": "0px"
+    },
     "10": {
       "value": "4px"
     },
@@ -8,6 +11,9 @@
     },
     "30": {
       "value": "8px"
+    },
+    "35": {
+      "value": "12px"
     },
     "40": {
       "value": "16px"

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -151,9 +151,11 @@ Object {
     "lineHeight90": "3.375rem",
   },
   "radii": Object {
+    "borderRadius0": "0px",
     "borderRadius10": "4px",
     "borderRadius20": "6px",
     "borderRadius30": "8px",
+    "borderRadius35": "12px",
     "borderRadius40": "16px",
     "borderRadius50": "24px",
     "borderRadiusCircle": "50%",


### PR DESCRIPTION
## Description of the change

- [ ] This PR adds the borderRadius0 to the tokens list so we can do things like this:

```
borderRadius={{ _: "borderRadius0", md: "borderRadius30" }}
```

This is necessary to avoid adding a borderRadius to an element in the app we are working on now. 

---- 
Plus: It also adds the `borderRadius35` because it's needed in the talent app.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
