### PR TITLE
feat(components): add tabs component and stories

### DIFF
--- a/.changeset/nasty-experts-divide.md
+++ b/.changeset/nasty-experts-divide.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+- Added `none` to border styles theme object.
+- Added `transparent` to colors theme object.

--- a/.changeset/weak-bears-wonder.md
+++ b/.changeset/weak-bears-wonder.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Tabs]: Added Tabs component, stories, and tests.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -78,6 +78,7 @@
     "lodash": "^4.17.21",
     "prettier": "^2.8.1",
     "pretty-quick": "^3.1.3",
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-uid": "^2.3.2",

--- a/packages/components/src/components/Tabs/Tab.tsx
+++ b/packages/components/src/components/Tabs/Tab.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Tab as TabPrimitive } from "ariakit/tab";
+import type { TabProps as TabPrimitiveProps } from "ariakit/tab";
+import PropTypes from "prop-types";
+import { Box } from "../../primitives/Box";
+
+export interface TabProps extends TabPrimitiveProps {
+  /** The tab contents. */
+  children: NonNullable<React.ReactNode>;
+  /** Disables the tab. Same as the HTML attribute. */
+  disabled?: boolean;
+  /** The id of the tab. Same as the HTML attribute. */
+  id?: string;
+}
+
+const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
+  ({ children, disabled, ...props }, ref) => {
+    return (
+      <Box.button
+        appearance="none"
+        as={TabPrimitive}
+        background="none"
+        border="none"
+        borderBottomColor={{
+          _: "transparent",
+          disabled: "transparent",
+          hover: "colorBorderWeaker",
+          selected: "colorBorderPrimary",
+        }}
+        borderBottomStyle="borderStyleSolid"
+        borderBottomWidth="borderWidth20"
+        // There's a conflict with TabPrimitiveProps from Ariakit. We have to convert color to string here because Ariakit doesn't like our responsive/state-based colors.
+        color={
+          {
+            _: "colorTextStronger",
+            disabled: "colorText",
+            hover: "colorTextStrongest",
+            selected: "colorTextLink",
+          } as unknown as string
+        }
+        cursor={{
+          _: "auto",
+          disabled: "not-allowed",
+          hover: "pointer",
+        }}
+        disabled={disabled}
+        flexGrow={1}
+        fontFamily="fontFamilyModerat"
+        fontSize="fontSize30"
+        fontWeight="fontWeightMedium"
+        lineHeight="lineHeight30"
+        outlineColor={{ focus: "colorBorderPrimary" }}
+        outlineOffset={{ focus: "borderWidth20" }}
+        outlineStyle={{ focus: "borderStyleSolid" }}
+        outlineWidth={{ focus: "borderWidth20" }}
+        paddingBottom="space20"
+        paddingLeft="space40"
+        paddingRight="space40"
+        paddingTop="space20"
+        textDecoration="none"
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </Box.button>
+    );
+  }
+);
+
+Tab.displayName = "Tab";
+
+Tab.propTypes = {
+  children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+};
+
+export { Tab };

--- a/packages/components/src/components/Tabs/TabList.tsx
+++ b/packages/components/src/components/Tabs/TabList.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { TabList as TabListPrimitive } from "ariakit/tab";
+import type { TabListProps as TabListPrimitiveProps } from "ariakit/tab";
+import PropTypes from "prop-types";
+import { Box } from "../../primitives/Box";
+import { TabsContext } from "./TabsContext";
+
+export interface TabListProps extends Omit<TabListPrimitiveProps, "state"> {
+  /** Required label for this Tabs component. Titles the entire Tabbing context for screen readers. */
+  "aria-label": string;
+  /** The child elements of the TabList. */
+  children: NonNullable<React.ReactNode>;
+}
+
+const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
+  ({ children, ...props }, ref) => {
+    const tab = React.useContext(TabsContext);
+
+    return (
+      <Box.div
+        as={TabListPrimitive}
+        display={tab.variant === "fitted" ? "flex" : "block"}
+        state={tab}
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+TabList.displayName = "TabList";
+
+TabList.propTypes = {
+  "aria-label": PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export { TabList };

--- a/packages/components/src/components/Tabs/TabPanel.tsx
+++ b/packages/components/src/components/Tabs/TabPanel.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { TabPanel as TabPanelPrimitive } from "ariakit/tab";
+import type { TabPanelProps as TabPanelPrimitiveProps } from "ariakit/tab";
+import PropTypes from "prop-types";
+import { Box } from "../../primitives/Box";
+import { TabsContext } from "./TabsContext";
+
+export interface TabPanelProps extends Omit<TabPanelPrimitiveProps, "state"> {
+  /** The child elements of the TabPanel. */
+  children: NonNullable<React.ReactNode>;
+  /** The id of the tab panel. Same as the HTML attribute. */
+  id?: string;
+}
+
+const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
+  ({ children, id, ...props }, ref) => {
+    const tab = React.useContext(TabsContext);
+
+    return (
+      <Box.div
+        as={TabPanelPrimitive}
+        id={id}
+        outline="none"
+        state={tab}
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+TabPanel.displayName = "TabPanel";
+
+TabPanel.propTypes = {
+  children: PropTypes.node.isRequired,
+  id: PropTypes.string,
+};
+
+export { TabPanel };

--- a/packages/components/src/components/Tabs/TabPanels.tsx
+++ b/packages/components/src/components/Tabs/TabPanels.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box } from "../../primitives/Box";
+
+export interface TabPanelsProps {
+  /** The child elements of the TabPanels. */
+  children: NonNullable<React.ReactNode>;
+}
+
+const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Box.div ref={ref} w="100%" {...props}>
+        {children}
+      </Box.div>
+    );
+  }
+);
+
+TabPanels.displayName = "TabPanels";
+
+TabPanels.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export { TabPanels };

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,228 @@
+import type { ComponentMeta } from "@storybook/react";
+import React from "react";
+import { Box } from "../../primitives/Box";
+import { Heading } from "../Heading";
+import { Paragraph } from "../Paragraph";
+import { Tabs } from "./Tabs";
+import { TabList } from "./TabList";
+import { TabPanels } from "./TabPanels";
+import { TabPanel } from "./TabPanel";
+import { Tab } from "./Tab";
+
+export default {
+  component: Tabs,
+  subcomponents: { Tab, TabList, TabPanels, TabPanel },
+  title: "Components/Tabs",
+} as ComponentMeta<typeof Tabs>;
+
+export const Default = (): JSX.Element => {
+  return (
+    <Tabs>
+      <TabList aria-label="Page tabs">
+        <Tab>Tab One</Tab>
+        <Tab>Tab Two</Tab>
+        <Tab>Tab Three</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab One
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Two
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Three
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export const InitialTab = (): JSX.Element => {
+  const selectedTab = "selected-tab";
+  return (
+    <Tabs initialTabId={selectedTab}>
+      <TabList aria-label="Page tabs">
+        <Tab>Tab One</Tab>
+        <Tab id={selectedTab}>Tab Two</Tab>
+        <Tab>Tab Three</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab One
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Two
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Three
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export const Disabled = (): JSX.Element => {
+  return (
+    <Tabs>
+      <TabList aria-label="Page tabs">
+        <Tab>Tab One</Tab>
+        <Tab disabled>Tab Two</Tab>
+        <Tab>Tab Three</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab One
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Two
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Three
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export const ReallyLongTab = (): JSX.Element => {
+  return (
+    <Tabs>
+      <TabList aria-label="Page tabs">
+        <Tab>Tab One</Tab>
+        <Tab>Lorem ipsum dolor sit dolor, consectetur consectetur dolor</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab One
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Two
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export const Fitted = (): JSX.Element => {
+  return (
+    <Tabs variant="fitted">
+      <TabList aria-label="Page tabs">
+        <Tab>Tab One</Tab>
+        <Tab>Tab Two</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab One
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+        <TabPanel>
+          <Box.div padding="space60">
+            <Heading as="h2" marginBottom="space0" size="heading50">
+              Tab Two
+            </Heading>
+            <Paragraph>
+              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+              sodales vel purus.
+            </Paragraph>
+          </Box.div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};

--- a/packages/components/src/components/Tabs/Tabs.test.tsx
+++ b/packages/components/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,67 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable sonarjs/no-duplicate-string */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Default as Tabs, InitialTab, Disabled } from "./Tabs.stories";
+
+describe("<Tabs />", () => {
+  it("renders correctly and selects different tabs", async () => {
+    render(<Tabs />);
+    const tabs = screen.getAllByRole("tab");
+    const tabPanels = screen.getAllByRole("tabpanel", { hidden: true });
+
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "false");
+
+    expect(tabPanels[0]).toBeVisible();
+    expect(tabPanels[1]).not.toBeVisible();
+    expect(tabPanels[2]).not.toBeVisible();
+
+    await userEvent.click(tabs[1]);
+
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "false");
+
+    expect(tabPanels[0]).not.toBeVisible();
+    expect(tabPanels[1]).toBeVisible();
+    expect(tabPanels[2]).not.toBeVisible();
+
+    await userEvent.click(tabs[2]);
+
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+
+    expect(tabPanels[0]).not.toBeVisible();
+    expect(tabPanels[1]).not.toBeVisible();
+    expect(tabPanels[2]).toBeVisible();
+  });
+
+  it("renders a preset selected tab correctly", () => {
+    render(<InitialTab />);
+    const tabs = screen.getAllByRole("tab");
+    const tabPanels = screen.getAllByRole("tabpanel", { hidden: true });
+
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "false");
+
+    expect(tabPanels[0]).not.toBeVisible();
+    expect(tabPanels[1]).toBeVisible();
+    expect(tabPanels[2]).not.toBeVisible();
+  });
+
+  it("renders a disabled tab correctly", () => {
+    render(<Disabled />);
+    const tabs = screen.getAllByRole("tab");
+
+    expect(tabs[0]).toBeEnabled();
+    expect(tabs[1]).toHaveAttribute("aria-disabled", "true");
+    expect(tabs[2]).toBeEnabled();
+  });
+});

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useTabState as useTabPrimitiveState } from "ariakit/tab";
+import PropTypes from "prop-types";
+import { Box } from "../../primitives/Box";
+import { TabsContext } from "./TabsContext";
+import type { TabsVariants } from "./types";
+
+export interface TabsProps {
+  /** Tells the Tabs which panel to load when it mounts. */
+  initialTabId?: string;
+  /** Changes the Tabs' to either fit the width of the containing element or not. */
+  variant?: TabsVariants;
+  /** The child elements. */
+  children: NonNullable<React.ReactNode>;
+}
+
+/** Tabs are labeled controls that allow users to switch between multiple views within a page */
+const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
+  ({ children, initialTabId, variant }, ref) => {
+    const tab = useTabPrimitiveState({
+      defaultSelectedId: initialTabId,
+    });
+
+    const value = React.useMemo(() => ({ ...tab, variant }), [tab, variant]);
+    const returnValue = (
+      <TabsContext.Provider value={value}>{children}</TabsContext.Provider>
+    );
+
+    return <Box.div ref={ref}>{returnValue}</Box.div>;
+  }
+);
+
+Tabs.displayName = "Tabs";
+
+Tabs.propTypes = {
+  initialTabId: PropTypes.string,
+  variant: PropTypes.oneOf(["fitted"]),
+  children: PropTypes.node.isRequired,
+};
+
+export { Tabs };

--- a/packages/components/src/components/Tabs/TabsContext.tsx
+++ b/packages/components/src/components/Tabs/TabsContext.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import type { TabState as TabStatePrimitiveProps } from "ariakit/tab";
+import type { TabsVariants } from "./types";
+
+export interface TabStateProps extends TabStatePrimitiveProps {
+  /** Tells the Tabs which panel to load when it mounts. */
+  initialTabId?: string;
+  /** Changes the Tabs' to either fit the width of the containing element or not. */
+  variant?: TabsVariants;
+}
+
+const TabsContext = React.createContext<TabStateProps>({} as TabStateProps);
+
+export { TabsContext };

--- a/packages/components/src/components/Tabs/index.ts
+++ b/packages/components/src/components/Tabs/index.ts
@@ -1,0 +1,7 @@
+export { useTabState } from "ariakit/tab";
+export * from "./Tabs";
+export * from "./TabList";
+export * from "./TabPanels";
+export * from "./TabPanel";
+export * from "./Tab";
+export * from "./types";

--- a/packages/components/src/components/Tabs/types.ts
+++ b/packages/components/src/components/Tabs/types.ts
@@ -1,0 +1,1 @@
+export type TabsVariants = "fitted" | undefined;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -23,6 +23,7 @@ export * from "./components/Search";
 export * from "./components/Select";
 export * from "./components/StepIndicator";
 export * from "./components/Table";
+export * from "./components/Tabs";
 export * from "./components/Textarea";
 export * from "./components/Toast";
 export * from "./components/Tooltip";

--- a/packages/components/src/primitives/Box/Box.tsx
+++ b/packages/components/src/primitives/Box/Box.tsx
@@ -6,7 +6,7 @@ import type {
 } from "@xstyled/styled-components";
 
 export interface BoxProps extends SystemProps {
-  backgroundColor?: SystemProp<keyof Theme["colors"], Theme> | "transparent";
+  backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
   borderColor?: SystemProp<keyof Theme["colors"], Theme>;
   borderTopColor?: SystemProp<keyof Theme["colors"], Theme>;
   borderRightColor?: SystemProp<keyof Theme["colors"], Theme>;

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -11,6 +11,7 @@ Object {
   "borderStyles": Object {
     "borderStyleDashed": "dashed",
     "borderStyleSolid": "solid",
+    "none": "none",
   },
   "borderWidths": Object {
     "borderWidth0": "0px",
@@ -80,6 +81,7 @@ Object {
     "colorTextStrongest": "#0F172A",
     "colorTextSuccess": "#047857",
     "colorTextWarning": "#B45309",
+    "transparent": "transparent",
   },
   "durations": Object {
     "fast-in": "250ms",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -20,6 +20,7 @@ export const theme = {
   ...defaultTheme,
   borderStyles: {
     ...BorderStyleTokens,
+    none: "none",
   },
   borderWidths: {
     ...BorderWidthTokens,
@@ -32,6 +33,7 @@ export const theme = {
       "linear-gradient(360deg, rgba(82, 244, 174, 0.12) 0%, rgba(131, 247, 197, 0.0575) 57.81%, rgba(255, 255, 255, 0) 100%)",
     colorBackgroundPreview:
       "linear-gradient(360deg, rgba(71, 94, 105, 0.08) 6.19%, rgba(71, 94, 105, 0.0504167) 57.3%, rgba(255, 255, 255, 0) 93.81%)",
+    transparent: "transparent",
   },
   fontSizes: {
     ...FontSizeTokens,


### PR DESCRIPTION
## Description of the change

Added Tabs component, stories and tests.

![Screenshot 2023-01-09 at 15 26 08](https://user-images.githubusercontent.com/1350081/211411785-152a9c2d-74a0-4703-8b34-1a1eefa8607e.png)

Also updated the theme border styles and color objects, so the values were no longer needed in Box.
- Added `none` to border styles theme object.
- Added `transparent` to colors theme object.

## Testing the change

- [ ] Fire up storybook

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
