### PR TITLE
fix(components): added sticky headers wrapper to table

### DIFF
--- a/.changeset/red-pans-rescue.md
+++ b/.changeset/red-pans-rescue.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+fixed sticky table headers by adding wrapper

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -12,6 +12,7 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import map from "lodash/map";
+import { Box } from "../../primitives/Box";
 import { Table, THead, TBody, Tr, Th, ThButton, Td } from "./index";
 
 const table: Meta<typeof Table> = {
@@ -82,24 +83,26 @@ Default.parameters = {
 
 export const StickyHeaders: Story = {
   render: () => (
-    <Table>
-      <THead isSticky>
-        <Tr>
-          <Th>Column 1</Th>
-          <Th>Column 2</Th>
-          <Th>Column 3</Th>
-        </Tr>
-      </THead>
-      <TBody>
-        {map([...Array.from({ length: 100 }).keys()], (index) => (
-          <Tr key={index}>
-            <Td>Content</Td>
-            <Td>Content</Td>
-            <Td>Content</Td>
+    <Box.div h="20rem" overflowY="auto">
+      <Table>
+        <THead isSticky>
+          <Tr>
+            <Th>Column 1</Th>
+            <Th>Column 2</Th>
+            <Th>Column 3</Th>
           </Tr>
-        ))}
-      </TBody>
-    </Table>
+        </THead>
+        <TBody>
+          {map([...Array.from({ length: 100 }).keys()], (index) => (
+            <Tr key={index}>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+    </Box.div>
   ),
 };
 


### PR DESCRIPTION
## Description of the change

The sticky headers story for table needed a wrapper to be seen on the story docs.

https://user-images.githubusercontent.com/52461415/214010593-d4625b1e-442b-4280-aedd-2c35d7043a14.mov


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
