### PR TITLE
fix(components): removed absolute positioning of helptext

### DIFF
--- a/.changeset/real-mice-remain.md
+++ b/.changeset/real-mice-remain.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/components": patch
+---
+
+- [FormInput, FormSelect, FormTextArea] - Removed absolute positioning in form element HelpText.
+- [FormSelect] - Added a controlled story example.

--- a/packages/components/src/components/FormInput/FormInput.tsx
+++ b/packages/components/src/components/FormInput/FormInput.tsx
@@ -36,7 +36,7 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
     ref
   ) => {
     return (
-      <Box.div position="relative">
+      <Box.div>
         <Label disabled={disabled} htmlFor={id} required={required}>
           {label}
         </Label>
@@ -52,11 +52,9 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
           {...props}
         />
         {helpText && (
-          <Box.div position="absolute">
-            <HelpText hasError={hasError} id={`${id}-help-text`}>
-              {helpText}
-            </HelpText>
-          </Box.div>
+          <HelpText hasError={hasError} id={`${id}-help-text`}>
+            {helpText}
+          </HelpText>
         )}
       </Box.div>
     );

--- a/packages/components/src/components/FormSelect/FormSelect.stories.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.stories.tsx
@@ -104,3 +104,20 @@ export const MultiSelect = (): JSX.Element => {
     />
   );
 };
+
+export const Controlled = (): JSX.Element => {
+  const [selectValue, setSelectValue] =
+    React.useState<SelectProps["value"]>("");
+  const selectID = useUID();
+  return (
+    <FormSelect
+      helpText="Please choose one of the values."
+      id={selectID}
+      items={selectItems}
+      label="Label text"
+      name="select-field"
+      setValue={(value) => setSelectValue(value)}
+      value={selectValue}
+    />
+  );
+};

--- a/packages/components/src/components/FormSelect/FormSelect.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.tsx
@@ -23,7 +23,7 @@ export interface FormSelectProps
 const FormSelect = React.forwardRef<HTMLButtonElement, FormSelectProps>(
   ({ id, required, label, helpText, hasError, disabled, ...props }, ref) => {
     return (
-      <Box.div position="relative">
+      <Box.div>
         <Label disabled={disabled} htmlFor={id} required={required}>
           {label}
         </Label>
@@ -37,11 +37,9 @@ const FormSelect = React.forwardRef<HTMLButtonElement, FormSelectProps>(
           {...props}
         />
         {helpText && (
-          <Box.div position="absolute">
-            <HelpText hasError={hasError} id={`${id}-help-text`}>
-              {helpText}
-            </HelpText>
-          </Box.div>
+          <HelpText hasError={hasError} id={`${id}-help-text`}>
+            {helpText}
+          </HelpText>
         )}
       </Box.div>
     );

--- a/packages/components/src/components/FormTextArea/FormTextArea.tsx
+++ b/packages/components/src/components/FormTextArea/FormTextArea.tsx
@@ -23,7 +23,7 @@ export interface FormTextAreaProps
 const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
   ({ id, required, label, helpText, disabled, hasError, ...props }, ref) => {
     return (
-      <Box.div position="relative">
+      <Box.div>
         <Label disabled={disabled} htmlFor={id} required={required}>
           {label}
         </Label>
@@ -37,11 +37,9 @@ const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
           {...props}
         />
         {helpText && (
-          <Box.div position="absolute">
-            <HelpText hasError={hasError} id={`${id}-help-text`}>
-              {helpText}
-            </HelpText>
-          </Box.div>
+          <HelpText hasError={hasError} id={`${id}-help-text`}>
+            {helpText}
+          </HelpText>
         )}
       </Box.div>
     );


### PR DESCRIPTION
## Description of the change

- [FormInput, FormSelect, FormTextArea] - Removed absolute positioning in form element HelpText.
- [FormSelect] - Added a controlled story example.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
