### PR TITLE
fix(components): added spacing to list items

### DIFF
--- a/.changeset/long-lobsters-study.md
+++ b/.changeset/long-lobsters-study.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[List]: Added `space30` margin to bottom of ListItems.

--- a/packages/components/src/components/List/ListItem.tsx
+++ b/packages/components/src/components/List/ListItem.tsx
@@ -10,7 +10,11 @@ export interface ListItemProps
 /** An item that is used inside a `List` */
 export const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>(
   ({ children, ...props }, ref) => (
-    <Box.li {...props} ref={ref}>
+    <Box.li
+      marginBottom={{ _: "space30", last: "space0" }}
+      {...props}
+      ref={ref}
+    >
       {children}
     </Box.li>
   )


### PR DESCRIPTION
## Description of the change

Fixed the missing bottom margins in ListItem. The last ListItem does not include the bottom margin.

![Screenshot 2023-01-27 at 11 46 39](https://user-images.githubusercontent.com/1350081/215158045-8dec05d2-087e-467a-a51b-3a94cbc79ef5.png)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
