### PR TITLE
feat(components): add ControlledFormTextArea for react hook form

### DIFF
--- a/.changeset/healthy-walls-sparkle.md
+++ b/.changeset/healthy-walls-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[FormTextArea] - Added a ControlledFormTextArea version so it can be easier used with React Hook Form.

--- a/packages/components/src/components/FormTextArea/ControlledFormTextArea.tsx
+++ b/packages/components/src/components/FormTextArea/ControlledFormTextArea.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Controller } from "react-hook-form";
+import type { ControllerProps, Control } from "react-hook-form";
+import { FormTextArea } from "./FormTextArea";
+import type { FormTextAreaProps } from "./FormTextArea";
+
+export interface ControlledFormTextAreaProps
+  extends Omit<ControllerProps, "control" | "defaultValue" | "render">,
+    Omit<FormTextAreaProps, "defaultValue" | "name" | "value"> {
+  /** Invoked with `useForm`. Set to any to allow `any` number of form inputs. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control?: Control<any>;
+}
+
+const ControlledFormTextArea = ({
+  control,
+  disabled,
+  helpText,
+  id,
+  label,
+  name,
+  placeholder,
+  readOnly,
+  required,
+  ...props
+}: ControlledFormTextAreaProps): JSX.Element => {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => (
+        <FormTextArea
+          {...field}
+          disabled={disabled}
+          hasError={fieldState.invalid}
+          helpText={helpText}
+          id={id}
+          label={label}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          required={(props.rules?.required as boolean) || required}
+          {...props}
+        />
+      )}
+      rules={props.rules}
+    />
+  );
+};
+
+ControlledFormTextArea.displayName = "ControlledFormTextArea";
+
+ControlledFormTextArea.propTypes = {
+  control: PropTypes.any,
+  disabled: PropTypes.bool,
+  helpText: PropTypes.node,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+};
+
+export { ControlledFormTextArea };

--- a/packages/components/src/components/FormTextArea/FormTextArea.stories.tsx
+++ b/packages/components/src/components/FormTextArea/FormTextArea.stories.tsx
@@ -1,11 +1,20 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 import { useUID } from "react-uid";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
+import { ControlledFormTextArea } from "./ControlledFormTextArea";
 import { FormTextArea } from "./FormTextArea";
 
 const meta: Meta<typeof FormTextArea> = {
   title: "Components/Form/FormTextArea",
   component: FormTextArea,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore ControlledFormTextArea has a required prop which confuses Storybook here.
+  subcomponents: { ControlledFormTextArea },
 };
 
 export default meta;
@@ -73,5 +82,104 @@ export const Controlled = (): JSX.Element => {
       onChange={(e) => setValue(e.target.value)}
       value={value}
     />
+  );
+};
+
+export const AsControlledFormTextArea = (): JSX.Element => {
+  const schema = yup.object().shape({
+    flavor: yup
+      .string()
+      .required("A flavor is required.")
+      .min(2, "Please enter more than two characters."),
+    flavor1: yup
+      .string()
+      .required("A flavor is required.")
+      .min(2, "Please enter more than two characters."),
+    flavor2: yup.string(),
+    flavor3: yup.string(),
+    flavor4: yup.string(),
+  });
+
+  interface FormInputs {
+    flavor: string;
+    flavor1: string;
+    flavor2: string;
+    flavor3: string;
+    flavor4: string;
+  }
+
+  const { control, handleSubmit, formState } = useForm<FormInputs>({
+    defaultValues: {
+      flavor: "",
+      flavor1: "W",
+      flavor2: "Chocolate",
+      flavor3: "Vanilla",
+      flavor4: "Strawberry",
+    },
+    resolver: yupResolver(schema),
+  });
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const onSubmit: SubmitHandler<FormInputs> = (data) =>
+    alert(JSON.stringify(data, null, 2));
+
+  const inputID = useUID();
+  return (
+    <Box.form onSubmit={handleSubmit(onSubmit)}>
+      <ControlledFormTextArea
+        control={control}
+        data-testid="test"
+        hasError={!!formState.errors.flavor}
+        helpText={
+          formState.errors.flavor
+            ? formState.errors.flavor.message
+            : "Please enter a flavor."
+        }
+        id={`${inputID}-1`}
+        label="Enter a flavor"
+        name="flavor"
+        placeholder="Maybe something crazy?"
+        required
+      />
+      <ControlledFormTextArea
+        control={control}
+        hasError={!!formState.errors.flavor1}
+        helpText={
+          formState.errors.flavor1
+            ? formState.errors.flavor1.message
+            : "Please enter a flavor."
+        }
+        id={`${inputID}-1`}
+        label="Enter a flavor"
+        name="flavor1"
+        placeholder="Maybe something crazy?"
+        required
+      />
+      <ControlledFormTextArea
+        control={control}
+        id={`${inputID}-2`}
+        label="Prefilled flavor"
+        name="flavor2"
+      />
+      <ControlledFormTextArea
+        control={control}
+        disabled
+        id={`${inputID}-2`}
+        label="Disabled flavor"
+        name="flavor3"
+      />
+      <ControlledFormTextArea
+        control={control}
+        id={`${inputID}-2`}
+        label="Read-Only flavor"
+        name="flavor4"
+        readOnly
+      />
+      <Box.div>
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </Box.form>
   );
 };

--- a/packages/components/src/components/FormTextArea/FormTextArea.test.tsx
+++ b/packages/components/src/components/FormTextArea/FormTextArea.test.tsx
@@ -1,12 +1,54 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { useForm } from "react-hook-form";
+import userEvent from "@testing-library/user-event";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { Box } from "../../primitives/Box";
 import {
   Default as FormTextArea,
   Required as RequiredFormTextArea,
   Disabled as DisabledFormTextArea,
 } from "./FormTextArea.stories";
+import { ControlledFormTextArea } from "./ControlledFormTextArea";
 
-describe("<FormInput />", () => {
+const ReactHookFormExample = (): JSX.Element => {
+  const schema = yup.object().shape({
+    flavor: yup.string().required("A flavor is required."),
+  });
+
+  interface FormInputs {
+    flavor: string;
+  }
+
+  const { control, formState } = useForm<FormInputs>({
+    defaultValues: {
+      flavor: "",
+    },
+    resolver: yupResolver(schema),
+  });
+  return (
+    <Box.form>
+      <ControlledFormTextArea
+        control={control}
+        data-testid="test"
+        hasError={!!formState.errors.flavor}
+        helpText={
+          formState.errors.flavor
+            ? formState.errors.flavor.message
+            : "Please enter a flavor."
+        }
+        id="flavor"
+        label="Enter a flavor"
+        name="flavor"
+        placeholder="Maybe something crazy?"
+        required
+      />
+    </Box.form>
+  );
+};
+
+describe("<FormTextArea />", () => {
   it("renders correctly", () => {
     render(<FormTextArea />);
 
@@ -27,5 +69,28 @@ describe("<FormInput />", () => {
   it("should render help text with the", () => {
     render(<RequiredFormTextArea />);
     expect(screen.getByText("Please enter some text.")).toBeInTheDocument();
+  });
+
+  it("should render a ControlledFormTextArea", async () => {
+    render(<ReactHookFormExample />);
+    const controlledInput = screen.getByRole("textbox");
+
+    expect(controlledInput).toBeInTheDocument();
+    expect(screen.getByLabelText("Enter a flavor")).toBeInTheDocument();
+    expect(screen.getByText("Please enter a flavor.")).toBeInTheDocument();
+    expect(controlledInput).toBeRequired();
+    expect(controlledInput).toHaveAttribute(
+      "placeholder",
+      "Maybe something crazy?"
+    );
+    expect(controlledInput).toHaveAttribute("name", "flavor");
+    expect(controlledInput).toHaveAttribute("id", "flavor");
+    expect(controlledInput).toHaveAttribute("data-testid", "test");
+
+    await userEvent.tab();
+
+    await userEvent.keyboard("Chocolate");
+
+    expect(controlledInput).toHaveValue("Chocolate");
   });
 });

--- a/packages/components/src/components/FormTextArea/FormTextArea.tsx
+++ b/packages/components/src/components/FormTextArea/FormTextArea.tsx
@@ -36,10 +36,12 @@ const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
           required={required}
           {...props}
         />
-        {helpText && (
+        {helpText ? (
           <HelpText hasError={hasError} id={`${id}-help-text`}>
             {helpText}
           </HelpText>
+        ) : (
+          <Box.div h="1rem" marginTop="space20" />
         )}
       </Box.div>
     );

--- a/packages/components/src/components/FormTextArea/index.ts
+++ b/packages/components/src/components/FormTextArea/index.ts
@@ -1,1 +1,2 @@
+export * from "./ControlledFormTextArea";
 export * from "./FormTextArea";


### PR DESCRIPTION
## Description of the change

Added ContolledFormTextArea so TextArea can be easily used with React Hook Form.

![Screenshot 2023-01-30 at 11 34 31](https://user-images.githubusercontent.com/1350081/215551456-dcb51ffa-17a0-433a-97ea-c88a3ded1f97.png)

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
