### PR TITLE
feat(components): add ControlledFormSelect for react hook form

### DIFF
--- a/.changeset/pink-falcons-work.md
+++ b/.changeset/pink-falcons-work.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[FormSelect] - Added a ControlledFormSelect version so it can be easier used with React Hook Form.

--- a/packages/components/src/components/FormSelect/ControlledFormSelect.tsx
+++ b/packages/components/src/components/FormSelect/ControlledFormSelect.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Controller } from "react-hook-form";
+import type { ControllerProps, Control } from "react-hook-form";
+import { FormSelect } from "./FormSelect";
+import type { FormSelectProps } from "./FormSelect";
+
+export interface ControlledFormSelectProps
+  extends Omit<ControllerProps, "control" | "defaultValue" | "render">,
+    Omit<FormSelectProps, "defaultValue" | "name" | "value"> {
+  /** Invoked with `useForm`. Set to any to allow `any` number of form inputs. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control?: Control<any>;
+}
+
+const ControlledFormSelect = ({
+  control,
+  disabled,
+  helpText,
+  id,
+  items,
+  label,
+  name,
+  placeholder,
+  required,
+  ...props
+}: ControlledFormSelectProps): JSX.Element => {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => (
+        <FormSelect
+          {...field}
+          disabled={disabled}
+          hasError={fieldState.invalid}
+          helpText={helpText}
+          id={id}
+          items={items}
+          label={label}
+          placeholder={placeholder}
+          required={(props.rules?.required as boolean) || required}
+          setValue={field.onChange}
+          {...props}
+        />
+      )}
+      rules={props.rules}
+    />
+  );
+};
+
+ControlledFormSelect.displayName = "ControlledFormSelect";
+
+ControlledFormSelect.propTypes = {
+  control: PropTypes.any,
+  disabled: PropTypes.bool,
+  helpText: PropTypes.node,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  required: PropTypes.bool,
+};
+
+export { ControlledFormSelect };

--- a/packages/components/src/components/FormSelect/FormSelect.stories.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 import { useUID } from "react-uid";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { useForm, SubmitHandler } from "react-hook-form";
 import type { SelectProps } from "../Select";
+import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
+import { ControlledFormSelect } from "./ControlledFormSelect";
 import { FormSelect } from "./FormSelect";
 
 const meta: Meta<typeof FormSelect> = {
@@ -119,5 +125,72 @@ export const Controlled = (): JSX.Element => {
       setValue={(value) => setSelectValue(value)}
       value={selectValue}
     />
+  );
+};
+
+export const AsControlledFormSelect = (): JSX.Element => {
+  const schema = yup.object().shape({
+    flavor: yup.string().required("A flavor is required."),
+    flavor1: yup.string(),
+    flavor2: yup.array(),
+  });
+
+  interface FormInputs {
+    flavor: string;
+    flavor1: string;
+    flavor2: string[];
+  }
+
+  const { control, handleSubmit, formState } = useForm<FormInputs>({
+    defaultValues: {
+      flavor: "",
+      flavor1: selectItems[1].value,
+      flavor2: [selectItems[0].value, selectItems[2].value],
+    },
+    resolver: yupResolver(schema),
+  });
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const onSubmit: SubmitHandler<FormInputs> = (data) =>
+    alert(JSON.stringify(data, null, 2));
+
+  const selectID = useUID();
+  return (
+    <Box.form onSubmit={handleSubmit(onSubmit)}>
+      <ControlledFormSelect
+        control={control}
+        hasError={!!formState.errors.flavor}
+        helpText={
+          formState.errors.flavor
+            ? formState.errors.flavor.message
+            : "Please select a flavor."
+        }
+        id={`${selectID}-1`}
+        items={selectItems}
+        label="Select a flavor"
+        name="flavor"
+        placeholder="Maybe something crazy?"
+        required
+      />
+      <ControlledFormSelect
+        control={control}
+        id={`${selectID}-2`}
+        items={selectItems}
+        label="Select a flavor"
+        name="flavor1"
+      />
+      <ControlledFormSelect
+        control={control}
+        id={`${selectID}-3`}
+        items={selectItems}
+        label="Select multiple flavors"
+        name="flavor2"
+      />
+      <Box.div>
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </Box.form>
   );
 };

--- a/packages/components/src/components/FormSelect/FormSelect.test.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.test.tsx
@@ -1,10 +1,58 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { useForm } from "react-hook-form";
+import userEvent from "@testing-library/user-event";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { Box } from "../../primitives/Box";
+import type { SelectProps } from "../Select";
 import {
   Default as FormSelect,
   Required as RequiredFormSelect,
   Disabled as DisabledFormSelect,
 } from "./FormSelect.stories";
+import { ControlledFormSelect } from "./ControlledFormSelect";
+
+const selectItems: SelectProps["items"] = [
+  { value: "chocolate", label: "Chocolate" },
+  { value: "vanilla", label: "Vanilla" },
+];
+
+const ReactHookFormExample = (): JSX.Element => {
+  const schema = yup.object().shape({
+    flavor: yup.string().required("A flavor is required."),
+  });
+
+  interface FormInputs {
+    flavor: string;
+  }
+
+  const { control, formState } = useForm<FormInputs>({
+    defaultValues: {
+      flavor: "",
+    },
+    resolver: yupResolver(schema),
+  });
+  return (
+    <Box.form>
+      <ControlledFormSelect
+        control={control}
+        data-testid="test"
+        hasError={!!formState.errors.flavor}
+        helpText={
+          formState.errors.flavor
+            ? formState.errors.flavor.message
+            : "Please select a flavor."
+        }
+        id="flavor"
+        items={selectItems}
+        label="Select a flavor"
+        name="flavor"
+        required
+      />
+    </Box.form>
+  );
+};
 
 describe("<FormSelect />", () => {
   it("renders correctly", () => {
@@ -29,5 +77,23 @@ describe("<FormSelect />", () => {
     expect(
       screen.getByText("Please choose one of the values.")
     ).toBeInTheDocument();
+  });
+
+  it("should render a ControlledFormSelect", async () => {
+    render(<ReactHookFormExample />);
+    const controlledSelect = screen.getByRole("combobox");
+    const selectOptions = screen.getAllByRole("option", { hidden: true });
+
+    expect(controlledSelect).toBeInTheDocument();
+    expect(screen.getByLabelText("Select a flavor")).toBeInTheDocument();
+    expect(screen.getByText("Please select a flavor.")).toBeInTheDocument();
+    expect(controlledSelect).toBeRequired();
+    expect(controlledSelect).toHaveAttribute("id", "flavor");
+    expect(controlledSelect).toHaveAttribute("data-testid", "test");
+
+    await userEvent.click(controlledSelect);
+    await userEvent.click(selectOptions[2]);
+
+    expect(selectOptions[2]).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/packages/components/src/components/FormSelect/FormSelect.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.tsx
@@ -36,10 +36,12 @@ const FormSelect = React.forwardRef<HTMLButtonElement, FormSelectProps>(
           required={required}
           {...props}
         />
-        {helpText && (
+        {helpText ? (
           <HelpText hasError={hasError} id={`${id}-help-text`}>
             {helpText}
           </HelpText>
+        ) : (
+          <Box.div h="1rem" marginTop="space20" />
         )}
       </Box.div>
     );

--- a/packages/components/src/components/FormSelect/index.ts
+++ b/packages/components/src/components/FormSelect/index.ts
@@ -1,1 +1,2 @@
+export * from "./ControlledFormSelect";
 export * from "./FormSelect";


### PR DESCRIPTION
## Description of the change

Added a ControlledFormSelect version so it can be easier used with React Hook Form.

![Screenshot 2023-02-02 at 10 28 12](https://user-images.githubusercontent.com/1350081/216384163-d8ac68d8-785e-49bf-ae21-bafbad2e24fd.png)

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
