### PR TITLE
feat: add textInverse color to Heading component

### DIFF
--- a/.changeset/slimy-phones-pay.md
+++ b/.changeset/slimy-phones-pay.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Heading] Add textInverse color

--- a/packages/components/src/components/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/Heading/Heading.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+import { Box } from "../../primitives/Box";
 import { Heading } from "./Heading";
 
 export default {
@@ -68,3 +69,11 @@ NoMargin.args = {
   children: "I'm a h2 element with no bottom margin.",
   marginBottom: "space0",
 };
+
+export const WithColorTextInverse = (): React.ReactElement => (
+  <Box.div backgroundColor="colorBackgroundPrimaryStrong" padding="space30">
+    <Heading color="colorTextInverse">
+      I&apos;m a h2 element in color white.
+    </Heading>
+  </Box.div>
+);

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -26,7 +26,8 @@ type HeadingSizeOptionsProp = HeadingSizeBreakpoints | HeadingSizeOptions;
 type HeadingFontColors =
   | "colorTextHeading"
   | "colorTextHeadingStrong"
-  | "colorTextHeadingStronger";
+  | "colorTextHeadingStronger"
+  | "colorTextInverse";
 
 export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   /** Sets the HTML element on render. */


### PR DESCRIPTION
## Description of the change

Adds the `colorTextInverse` to "HeadingFontColors" type.  

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
