### PR TITLE
feat(theme): add none value to box shadow

### DIFF
--- a/.changeset/five-radios-knock.md
+++ b/.changeset/five-radios-knock.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/theme": patch
+---
+
+Add "none" value to box shadow

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -178,6 +178,7 @@ Object {
     "xs": 0,
   },
   "shadows": Object {
+    "none": "none",
     "shadow": "0px 3px 24px rgba(15, 23, 42, 0.05)",
     "shadowFocus": "0px 1px 2px rgba(0, 0, 0, 0.05), 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 4px #102EE9",
     "shadowStrong": "0px 8px 24px rgba(15, 23, 42, 0.08)",

--- a/packages/theme/src/theme/default.ts
+++ b/packages/theme/src/theme/default.ts
@@ -55,6 +55,7 @@ export const theme = {
     shadowStrong: "0px 8px 24px rgba(15, 23, 42, 0.08)",
     shadowFocus:
       "0px 1px 2px rgba(0, 0, 0, 0.05), 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 4px #102EE9",
+    none: "none",
   },
   sizes: {
     ...SizeTokens,


### PR DESCRIPTION
## Description of the change

Add the option to set the boxShadow as "none". This is very useful for elements that may have a box shadow value in a certain screen breakpoint but not on others (ex.: mobile vs desktop).

Example usage

```javascript
  boxShadow={{ _: "shadow", md: "none" }}
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
