### PR TITLE
[NOISSUE] fix: add right value to colorAvatarBackgroundPink token

### DIFF
--- a/.changeset/thirty-donuts-begin.md
+++ b/.changeset/thirty-donuts-begin.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/design-tokens": patch
+"@localyze-pluto/theme": patch
+---
+
+Replace token avatar-background-pink #A9EBE8 by #FF9788

--- a/packages/design-tokens/src/tokens/color.tokens.json
+++ b/packages/design-tokens/src/tokens/color.tokens.json
@@ -173,7 +173,7 @@
       "value": "#A9EBE8"
     },
     "avatar-background-pink": {
-      "value": "#A9EBE8"
+      "value": "#FF9788"
     }
   }
 }

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -26,7 +26,7 @@ Object {
     "colorAvatarBackgroundGreen": "#8AFECC",
     "colorAvatarBackgroundLightBlue": "#A9EBE8",
     "colorAvatarBackgroundOrange": "#FBBF24",
-    "colorAvatarBackgroundPink": "#A9EBE8",
+    "colorAvatarBackgroundPink": "#FF9788",
     "colorAvatarBackgroundYellow": "#FDE68A",
     "colorBackground": "#FFFFFF",
     "colorBackgroundBody": "#F7F9FF",


### PR DESCRIPTION
## Description of the change

- Fix color token since the changed value is actually colorAvatarBackgroundLightBlue

before:
![Screen Shot 2023-03-21 at 18 14 21](https://user-images.githubusercontent.com/2047941/226742433-bb6860e0-0e8a-48e8-b859-2f33120d0194.png)


after:
![Screen Shot 2023-03-21 at 18 14 04](https://user-images.githubusercontent.com/2047941/226742416-d56e9d1e-095e-419a-90da-b333ae0f36ad.png)

## Testing the change

- [x] Write your testing instructions here

the correct color can be checked on storybook /docs/components-avatar--docs

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
