### PR TITLE
fix: add the correct color on the unit test, allow style overwriting

### DIFF
--- a/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -23,7 +23,7 @@ export const Large = (): JSX.Element => (
 export const WithCustomColors = (): JSX.Element => (
   <Box.div display="flex" flexDirection="column" gap="space40">
     <ProgressBar
-      backgroundColor="colorAvatarBackgroundPink"
+      backgroundcolor="colorAvatarBackgroundPink"
       indicatorColor="colorAvatarBackgroundGreen"
       value={25}
     />

--- a/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
@@ -22,7 +22,7 @@ describe("<ProgressBar />", () => {
 
   it("renders background color correctly", () => {
     render(
-      <ProgressBar backgroundColor="colorAvatarBackgroundPink" value={25} />
+      <ProgressBar backgroundcolor="colorAvatarBackgroundPink" value={25} />
     );
 
     const renderedProgressBar = screen.getByRole("progressbar");

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -11,21 +11,25 @@ export interface ProgressBarProps {
   value: number;
   /** The color of the progress indicator */
   indicatorColor?: SystemProp<keyof Theme["colors"], Theme>;
+  /** Overwrites the styles of the indicator. */
+  indicatorStyle?: React.CSSProperties;
   /** The background color of the progress bar */
-  backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
+  backgroundcolor?: SystemProp<keyof Theme["colors"], Theme>;
   /** Sets the size of the progress bar. */
   size?: ProgressBarSizeOptions;
+  /** Overwrites the styles of the progress bar. */
+  style?: React.CSSProperties;
 }
 
 interface StyledProgressProps extends Omit<ProgressProps, "value"> {
   value: number;
-  backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
+  backgroundcolor?: SystemProp<keyof Theme["colors"], Theme>;
   h: SystemProp<keyof Theme["space"], Theme>;
   radius: SystemProp<keyof Theme["radii"], Theme>;
 }
 
 interface StyledIndicatorProps {
-  backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
+  backgroundcolor?: SystemProp<keyof Theme["colors"], Theme>;
   radius: SystemProp<keyof Theme["radii"], Theme>;
 }
 
@@ -33,7 +37,7 @@ const StyledProgress = styled.div`
   background-color: ${(props: StyledProgressProps) =>
     get(
       theme.colors,
-      String(props.backgroundColor),
+      String(props.backgroundcolor),
       theme.colors.colorBackgroundWeak
     )};
   border-radius: ${(props: StyledProgressProps) =>
@@ -53,7 +57,7 @@ const StyledIndicator = styled.div`
   background-color: ${(props: StyledIndicatorProps) =>
     get(
       theme.colors,
-      String(props.backgroundColor),
+      String(props.backgroundcolor),
       theme.colors.colorBackgroundPrimaryWeak
     )};
 `;
@@ -61,7 +65,14 @@ const StyledIndicator = styled.div`
 /** Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
 const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
-    { value, size = "small", indicatorColor, backgroundColor, ...props },
+    {
+      value,
+      size = "small",
+      indicatorColor,
+      backgroundcolor,
+      indicatorStyle,
+      ...props
+    },
     ref
   ) => {
     const borderRadius = size === "large" ? "borderRadius50" : "borderRadius10";
@@ -69,7 +80,7 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     return (
       <StyledProgress
         as={Root}
-        backgroundColor={backgroundColor}
+        backgroundcolor={backgroundcolor}
         h={size === "large" ? "space40" : "space25"}
         radius={borderRadius}
         ref={ref}
@@ -78,9 +89,12 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
       >
         <StyledIndicator
           as={Indicator}
-          backgroundColor={indicatorColor}
+          backgroundcolor={indicatorColor}
           radius={borderRadius}
-          style={{ transform: `translateX(-${100 - value}%)` }}
+          style={{
+            transform: `translateX(-${100 - value}%)`,
+            ...indicatorStyle,
+          }}
         />
       </StyledProgress>
     );

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -26,7 +26,7 @@ Object {
     "colorAvatarBackgroundGreen": "#8AFECC",
     "colorAvatarBackgroundLightBlue": "#A9EBE8",
     "colorAvatarBackgroundOrange": "#FBBF24",
-    "colorAvatarBackgroundPink": "#A9EBE8",
+    "colorAvatarBackgroundPink": "#FF9788",
     "colorAvatarBackgroundYellow": "#FDE68A",
     "colorBackground": "#FFFFFF",
     "colorBackgroundBody": "#F7F9FF",


### PR DESCRIPTION
## Description of the change
- Add style and indicatorStyle props to overwrite component style without a token change
- Changes from `backgroundColor` to `backgroundcolor` to avoid a React error

Write out a good description of the change. A screenshot or video will also be helpful.

## Testing the change

- [ ] The component should allow overwriting styles through style and indicatorStyle props

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
