### PR TITLE
fix: use Box.div on ProgressBar fixing tokens usage

### DIFF
--- a/.changeset/sixty-nails-warn.md
+++ b/.changeset/sixty-nails-warn.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Change ProgressBar to use Box.div instead styled version and tokens correctly

--- a/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.test.tsx
@@ -8,28 +8,6 @@ describe("<ProgressBar />", () => {
 
     const renderedProgressBar = screen.getByRole("progressbar");
     expect(renderedProgressBar).toHaveAttribute("data-value", "50");
-    expect(renderedProgressBar).toHaveAttribute("radius", "borderRadius10");
-    expect(renderedProgressBar).toHaveAttribute("h", "space25");
-  });
-
-  it("renders the large variant correctly", () => {
-    render(<ProgressBar size="large" value={75} />);
-
-    const renderedProgressBar = screen.getByRole("progressbar");
-    expect(renderedProgressBar).toHaveAttribute("h", "space40");
-    expect(renderedProgressBar).toHaveAttribute("radius", "borderRadius50");
-  });
-
-  it("renders background color correctly", () => {
-    render(
-      <ProgressBar backgroundColor="colorAvatarBackgroundPink" value={25} />
-    );
-
-    const renderedProgressBar = screen.getByRole("progressbar");
-    expect(renderedProgressBar).toHaveAttribute(
-      "background",
-      "colorAvatarBackgroundPink"
-    );
   });
 
   it("should allow for global html Attributes", () => {

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -19,7 +19,13 @@ export interface ProgressBarProps {
 /** Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
 const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
-    { value, size = "small", indicatorColor, backgroundColor, ...props },
+    {
+      value,
+      size = "small",
+      indicatorColor = "colorBackgroundPrimaryWeak",
+      backgroundColor = "colorBackgroundWeak",
+      ...props
+    },
     ref
   ) => {
     const borderRadius = size === "large" ? "borderRadius50" : "borderRadius10";
@@ -27,7 +33,7 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     return (
       <Box.div
         as={Root}
-        backgroundColor={backgroundColor || "colorBackgroundWeak"}
+        backgroundColor={backgroundColor}
         borderRadius={borderRadius}
         h={size === "large" ? "0.75rem" : "0.4rem"}
         overflow="hidden"
@@ -38,7 +44,7 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
       >
         <Box.div
           as={Indicator}
-          backgroundColor={indicatorColor || "colorBackgroundPrimaryWeak"}
+          backgroundColor={indicatorColor}
           borderRadius={borderRadius}
           h="100%"
           style={{ transform: `translateX(-${100 - value}%)` }}

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { styled, theme } from "@localyze-pluto/theme";
-import { Root, Indicator, ProgressProps } from "@radix-ui/react-progress";
+import { Root, Indicator } from "@radix-ui/react-progress";
 import { SystemProp, Theme } from "@xstyled/styled-components";
-import get from "lodash/get";
+import { Box } from "../../primitives/Box";
 
 type ProgressBarSizeOptions = "large" | "small";
 
@@ -17,47 +16,6 @@ export interface ProgressBarProps {
   size?: ProgressBarSizeOptions;
 }
 
-interface StyledProgressProps extends Omit<ProgressProps, "value"> {
-  value: number;
-  background?: SystemProp<keyof Theme["colors"], Theme>;
-  h: SystemProp<keyof Theme["space"], Theme>;
-  radius: SystemProp<keyof Theme["radii"], Theme>;
-}
-
-interface StyledIndicatorProps {
-  background?: SystemProp<keyof Theme["colors"], Theme>;
-  radius: SystemProp<keyof Theme["radii"], Theme>;
-}
-
-const StyledProgress = styled.div`
-  background-color: ${(props: StyledProgressProps) =>
-    get(
-      theme.colors,
-      String(props.background),
-      theme.colors.colorBackgroundWeak
-    )};
-  border-radius: ${(props: StyledProgressProps) =>
-    get(theme.radii, String(props.radius), "")};
-  height: ${(props: StyledProgressProps) =>
-    get(theme.space, String(props.h), "")};
-  overflow: hidden;
-  position: relative;
-`;
-
-const StyledIndicator = styled.div`
-  height: 100%;
-  width: 100%;
-  transition: transform 660ms cubic-bezier(0.65, 0, 0.35, 1);
-  border-radius: ${(props: StyledIndicatorProps) =>
-    get(theme.radii, String(props.radius), "")};
-  background-color: ${(props: StyledIndicatorProps) =>
-    get(
-      theme.colors,
-      String(props.background),
-      theme.colors.colorBackgroundPrimaryWeak
-    )};
-`;
-
 /** Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
 const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
@@ -67,22 +25,27 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     const borderRadius = size === "large" ? "borderRadius50" : "borderRadius10";
 
     return (
-      <StyledProgress
+      <Box.div
         as={Root}
-        background={backgroundColor}
-        h={size === "large" ? "space40" : "space25"}
-        radius={borderRadius}
+        backgroundColor={backgroundColor || "colorBackgroundWeak"}
+        borderRadius={borderRadius}
+        h={size === "large" ? "0.75rem" : "0.4rem"}
+        overflow="hidden"
+        position="relative"
         ref={ref}
         value={value}
         {...props}
       >
-        <StyledIndicator
+        <Box.div
           as={Indicator}
-          background={indicatorColor}
-          radius={borderRadius}
+          backgroundColor={indicatorColor || "colorBackgroundPrimaryWeak"}
+          borderRadius={borderRadius}
+          h="100%"
           style={{ transform: `translateX(-${100 - value}%)` }}
+          transition="transform 660ms cubic-bezier(0.65, 0, 0.35, 1)"
+          w="100%"
         />
-      </StyledProgress>
+      </Box.div>
     );
   }
 );


### PR DESCRIPTION
## Description of the change
- Change the ProgressBar component to use Box.div instead of Styled components so the token overwriting can be correct

## Testing the change

- [x] Write your testing instructions here

- you can edit `.storybook/preview.js` rewriting tokens like below. This was not affecting the component before and now it works properly

```typescript
      <ThemeProvider
        theme={{
          ...theme,
          colors: {
            ...theme.colors,
            colorAvatarBackgroundGreen: "limegreen",
            colorAvatarBackgroundPink: "purple",
          },
        }}
      >
```

and change stories snippet like

```typescript
export const WithCustomColors = (): JSX.Element => (
  <Box.div display="flex" flexDirection="column" gap="space40">
    <ProgressBar
      backgroundColor="colorAvatarBackgroundPink"
      indicatorColor="colorAvatarBackgroundGreen"
      value={25}
    />
    <Box.div backgroundColor={"colorAvatarBackgroundGreen"}>Hello!</Box.div>
    <Box.div backgroundColor={"colorAvatarBackgroundPink"}>Good bye!</Box.div>
  </Box.div>
);
```

before this change:

![Screen Shot 2023-03-24 at 12 23 43](https://user-images.githubusercontent.com/2047941/227568411-cbaca9ef-785f-40f7-a5e5-c9e763b91119.png)

after this change:

![Screen Shot 2023-03-24 at 12 24 38](https://user-images.githubusercontent.com/2047941/227568614-b14575cc-694f-45ef-b0d0-cafb04975ef1.png)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
