### PR TITLE
fix(components): fix style props in progressBar

### DIFF
--- a/.changeset/violet-poems-remain.md
+++ b/.changeset/violet-poems-remain.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Added style props to the progressBar

--- a/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -30,6 +30,22 @@ export const WithCustomColors = (): JSX.Element => (
   </Box.div>
 );
 
+export const WithOverWrittenStyles = (): JSX.Element => (
+  <Box.div display="flex" flexDirection="column" gap="space40">
+    <ProgressBar
+      backgroundColor="colorAvatarBackgroundPink"
+      indicatorColor="colorAvatarBackgroundGreen"
+      indicatorStyle={{
+        backgroundColor: "purple",
+      }}
+      style={{
+        backgroundColor: "red",
+      }}
+      value={25}
+    />
+  </Box.div>
+);
+
 export const Animated = (): JSX.Element => {
   const [progress, setProgress] = useState(13);
 

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -14,6 +14,10 @@ export interface ProgressBarProps {
   backgroundColor?: SystemProp<keyof Theme["colors"], Theme>;
   /** Sets the size of the progress bar. */
   size?: ProgressBarSizeOptions;
+  /** The style of the progress indicator background color, should be an object with html style attributes */
+  style?: React.CSSProperties;
+  /** The style of the progress indicator, should be an object with html style attributes */
+  indicatorStyles?: React.CSSProperties;
 }
 
 /** Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
@@ -24,6 +28,7 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
       size = "small",
       indicatorColor = "colorBackgroundPrimaryWeak",
       backgroundColor = "colorBackgroundWeak",
+      indicatorStyles,
       ...props
     },
     ref
@@ -47,7 +52,10 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
           backgroundColor={indicatorColor}
           borderRadius={borderRadius}
           h="100%"
-          style={{ transform: `translateX(-${100 - value}%)` }}
+          style={{
+            transform: `translateX(-${100 - value}%)`,
+            ...indicatorStyles,
+          }}
           transition="transform 660ms cubic-bezier(0.65, 0, 0.35, 1)"
           w="100%"
         />


### PR DESCRIPTION
## Description of the change

We need to be able to style the indicator and the background of the indicator, so we added props for both of these so we could over write them.

<img width="960" alt="Screenshot 2023-03-27 at 16 00 38" src="https://user-images.githubusercontent.com/52461415/227962273-cdec4e5f-d7dc-4186-ad0f-eab041221ebb.png">

## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
