### PR TITLE
fix(tokens): Replace map icon token

### DIFF
--- a/.changeset/metal-phones-impress.md
+++ b/.changeset/metal-phones-impress.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/design-tokens": minor
+"@localyze-pluto/theme": minor
+---
+
+Fix colorIconMap token

--- a/packages/design-tokens/src/tokens/color.tokens.json
+++ b/packages/design-tokens/src/tokens/color.tokens.json
@@ -173,7 +173,7 @@
       "value": "#6EE7B7"
     },
     "icon-map": {
-      "value": "#4A63FC"
+      "value": "#0B1F9C"
     },
     "step-progress-background": {
       "value": "#4A63FC"
@@ -187,7 +187,6 @@
     "footer-avatar-decoration": {
       "value": "#102EE9"
     },
-
     "footer-text": {
       "value": "#041162"
     },

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -76,7 +76,7 @@ Object {
     "colorHeaderTextInverse": "#FFFFFF",
     "colorIconError": "#DC2626",
     "colorIconInfo": "#102EE9",
-    "colorIconMap": "#4A63FC",
+    "colorIconMap": "#0B1F9C",
     "colorIconStrong": "#334155",
     "colorIconStronger": "#0F172A",
     "colorIconSuccess": "#059669",


### PR DESCRIPTION
## Description of the change
- change colorIconMap from #4A63FC to #0B1F9C

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] 
### Development
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

