### PR TITLE
fix: make file upload title disabled

### DIFF
--- a/.changeset/green-sloths-wait.md
+++ b/.changeset/green-sloths-wait.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[File Uploader] Remove link from file title when status is disabled

--- a/packages/components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.stories.tsx
@@ -4,6 +4,8 @@ import Uppy from "@uppy/core";
 import { FileUploader } from "./FileUploader";
 import { FileUploaderButton } from "./FileUploaderButton";
 
+const FILE_URL = "http://file-path/file.pdf";
+
 export default {
   component: FileUploader,
   title: "Components/FileUploader",
@@ -53,7 +55,7 @@ Success.args = {
   label: "Passport scan",
   fileSize: "2MB",
   fileName: "my_passport_scap.pdf",
-  fileUrl: "http://file-path/file.pdf",
+  fileUrl: FILE_URL,
   children: (
     <FileUploaderButton trailingIcon="ArrowUpTrayIcon" variant="secondary">
       Upload
@@ -84,7 +86,7 @@ Multiline.parameters = {
 export const SuccessWithoutFileInfo = Template.bind({});
 SuccessWithoutFileInfo.args = {
   label: "Passport scan",
-  fileUrl: "http://file-path/file.pdf",
+  fileUrl: FILE_URL,
   children: (
     <FileUploaderButton trailingIcon="ArrowUpTrayIcon" variant="secondary">
       Upload
@@ -115,6 +117,7 @@ WithError.parameters = {
 
 export const Disabled = Template.bind({});
 Disabled.args = {
+  fileUrl: FILE_URL,
   label: "Employment Contract",
   maxFileSize: "3MB",
   disabled: true,

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -100,7 +100,11 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
               flexGrow={1}
               justifyContent={isMobile ? "top" : "center"}
             >
-              <FileUploaderTitle fileUrl={fileUrl} label={label} />
+              <FileUploaderTitle
+                fileUrl={fileUrl}
+                label={label}
+                status={status}
+              />
               <Box.div
                 alignItems={{ _: "left", md: "center" }}
                 display="flex"

--- a/packages/components/src/components/FileUploader/FileUploaderTitle.tsx
+++ b/packages/components/src/components/FileUploader/FileUploaderTitle.tsx
@@ -5,11 +5,13 @@ import { Text } from "../../primitives/Text";
 export const FileUploaderTitle = ({
   label,
   fileUrl,
+  status,
 }: {
   label: string;
+  status: string;
   fileUrl?: string;
 }): React.ReactElement => {
-  if (fileUrl) {
+  if (fileUrl && status !== "disabled") {
     return (
       <Anchor href={fileUrl} target="_blank">
         {label}


### PR DESCRIPTION
## Description of the change

We should also handle the file uploaded title when the component status is disabled. For this case, we are sending the status to the FileUploaderTitle and checking if the status is disabled to create the link or not in the title.

![image](https://user-images.githubusercontent.com/5320963/229826678-a6bf52d0-9872-41ba-96e1-5b094c4476f8.png)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
