### PR TITLE
feat: create controlled checkbox

### DIFF
--- a/.changeset/slimy-crabs-attend.md
+++ b/.changeset/slimy-crabs-attend.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Checkbox] - Added a ControlledCheckbox version so it can be easier used with React Hook Form

--- a/packages/components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,8 +1,11 @@
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import React, { useState, useRef } from "react";
+import { useForm } from "react-hook-form";
 import { Button } from "../Button";
 import { Text } from "../../primitives/Text";
+import { Box } from "../..";
 import { Checkbox, CheckedState } from "./Checkbox";
+import { ControlledCheckbox } from "./ControlledCheckbox/ControlledCheckbox";
 
 export default {
   component: Checkbox,
@@ -118,4 +121,40 @@ export const Controlled = (): React.ReactElement => {
       </Checkbox>
     </form>
   );
+};
+
+export const AsControlledCheckbox = (): JSX.Element => {
+  const { control, handleSubmit } = useForm({
+    defaultValues: {
+      checkbox: false,
+    },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
+    >
+      <ControlledCheckbox
+        control={control}
+        id="checkbox-controlled"
+        name="checkbox"
+      >
+        Working example with React Hook Form
+      </ControlledCheckbox>
+
+      <Box.div marginTop="space40">
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </form>
+  );
+};
+AsControlledCheckbox.parameters = {
+  docs: {
+    description: {
+      story:
+        "If you want to use the Checkbox with [React Hook Form](https://react-hook-form.com/), use the ControlledCheckbox component instead.",
+    },
+  },
 };

--- a/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.test.tsx
+++ b/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.test.tsx
@@ -47,12 +47,15 @@ describe("<ControlledCheckbox />", () => {
 
     const onSubmit = jest.fn();
     render(<ReactHookFormExample onSubmit={onSubmit} />);
+    const checkbox = screen.getByRole("checkbox", { name: "Checkbox" });
 
+    expect(checkbox).toHaveAttribute("data-state", "unchecked");
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(onSubmit).toHaveBeenCalledWith({ checkbox: false });
 
-    await user.click(screen.getByRole("checkbox", { name: "Checkbox" }));
+    await user.click(checkbox);
+    expect(checkbox).toHaveAttribute("data-state", "checked");
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(onSubmit).toHaveBeenNthCalledWith(2, { checkbox: true });

--- a/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.test.tsx
+++ b/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import React from "react";
+import UserEvent from "@testing-library/user-event";
+import { Box, Button } from "../../..";
+import { ControlledCheckbox } from "./ControlledCheckbox";
+
+const ReactHookFormExample = ({
+  onSubmit,
+}: {
+  onSubmit: (data: { checkbox: boolean }) => void;
+}): JSX.Element => {
+  const { control, handleSubmit } = useForm({
+    defaultValues: {
+      checkbox: false,
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit((data) => onSubmit(data))}>
+      <ControlledCheckbox
+        control={control}
+        id="checkbox-controlled"
+        name="checkbox"
+      >
+        Checkbox
+      </ControlledCheckbox>
+
+      <Box.div marginTop="space40">
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </form>
+  );
+};
+
+describe("<ControlledCheckbox />", () => {
+  it("should render and work with React Hook Form", async () => {
+    window.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+
+    const user = UserEvent.setup();
+
+    const onSubmit = jest.fn();
+    render(<ReactHookFormExample onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ checkbox: false });
+
+    await user.click(screen.getByRole("checkbox", { name: "Checkbox" }));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onSubmit).toHaveBeenNthCalledWith(2, { checkbox: true });
+  });
+});

--- a/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.tsx
+++ b/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Control, Controller } from "react-hook-form";
+import type { ControllerProps } from "react-hook-form";
+import { CheckedState } from "@radix-ui/react-checkbox";
+import { Checkbox } from "../Checkbox";
+import type { CheckboxProps } from "../Checkbox";
+
+export interface ControlledCheckboxProps
+  extends Pick<ControllerProps, "name" | "rules">,
+    Omit<CheckboxProps, "checked" | "error" | "name" | "onBlur" | "value"> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control?: Control<any>;
+}
+
+const ControlledCheckbox = ({
+  control,
+  disabled,
+  id,
+  name,
+  ...props
+}: ControlledCheckboxProps): JSX.Element => {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => (
+        <Checkbox
+          checked={field.value as CheckedState}
+          disabled={disabled}
+          error={fieldState.invalid}
+          id={id}
+          onBlur={field.onBlur}
+          onCheckedChange={(checkState) => {
+            field.onChange(checkState);
+          }}
+          ref={field.ref}
+          {...props}
+        />
+      )}
+      rules={props.rules}
+    />
+  );
+};
+
+ControlledCheckbox.displayName = "ControlledCheckbox";
+
+ControlledCheckbox.propTypes = {
+  control: PropTypes.any,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export { ControlledCheckbox };

--- a/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.tsx
+++ b/packages/components/src/components/Checkbox/ControlledCheckbox/ControlledCheckbox.tsx
@@ -9,6 +9,7 @@ import type { CheckboxProps } from "../Checkbox";
 export interface ControlledCheckboxProps
   extends Pick<ControllerProps, "name" | "rules">,
     Omit<CheckboxProps, "checked" | "error" | "name" | "onBlur" | "value"> {
+  // Invoked with `useForm`. Set to any to allow `any` number of form inputs.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control?: Control<any>;
 }


### PR DESCRIPTION
## Description of the change

This creates a ControlledCheckbox component to be easily used with React Hook Forms.

## Testing the change

- [ ] Visit the As Controlled Checkbox story for Checkbox

## Type of change

- [ ] New feature (non-breaking change that adds functionality)