### PR TITLE
chore: disable auto rebase from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       time: "04:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 20
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "automerge"


### PR DESCRIPTION
## Description of the change

This PR:
* use the `rebase-strategy` as disabled to stop rebasing dependabot PRs and making us rebase them when merging it

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
