### PR TITLE
Select component fixes

### DIFF
--- a/.changeset/spicy-seals-deny.md
+++ b/.changeset/spicy-seals-deny.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[ControlledFormSelect] - Fix: Make `control` required as that is necessary for the component to work
+[Select] - Fix: onBlur was previously getting triggered when clicking on a select item

--- a/packages/components/src/components/FormSelect/ControlledFormSelect.tsx
+++ b/packages/components/src/components/FormSelect/ControlledFormSelect.tsx
@@ -10,7 +10,7 @@ export interface ControlledFormSelectProps
     Omit<FormSelectProps, "defaultValue" | "hasError" | "name" | "value"> {
   /** Invoked with `useForm`. Set to any to allow `any` number of form inputs. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  control?: Control<any>;
+  control: Control<any>;
 }
 
 const ControlledFormSelect = ({

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -192,6 +192,16 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           w="100%"
           {...getSelectStyles(disabled, hasError)}
           {...props}
+          onBlur={(event) => {
+            if (event.defaultPrevented) {
+              return;
+            }
+            const popover = select.popoverRef.current;
+            if (popover?.contains(event.relatedTarget)) {
+              return;
+            }
+            props.onBlur?.(event);
+          }}
           state={select}
         >
           <Box.div


### PR DESCRIPTION
## Description of the change

The onBlur of the Select was getting triggered when clicking on a menu item causing issues with validating on blur. The Select now follows a similar approach seen in AriaKit's FormSelect component to prevent this.

I've also made `control` prop required for the `ControlledFormSelect` component as the component throws an error without it.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)