### PR TITLE
feat(tokens): add color background outline hover token

### DIFF
--- a/.changeset/twelve-mails-appear.md
+++ b/.changeset/twelve-mails-appear.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/design-tokens": patch
+"@localyze-pluto/components": patch
+"@localyze-pluto/theme": patch
+---
+
+Add color background outline hover token

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -128,7 +128,7 @@ const getButtonVariantStyles = (
         borderColor: { _: "colorBorderPrimary", disabled: "colorBorder" },
         backgroundColor: {
           active: "colorBackground",
-          hover: "colorBackgroundInfo",
+          hover: "colorBackgroundOutlineHover",
         },
         outlineColor: { focus: "colorBorderPrimary" },
       };

--- a/packages/design-tokens/src/tokens/color.tokens.json
+++ b/packages/design-tokens/src/tokens/color.tokens.json
@@ -79,6 +79,9 @@
     "background-decorative-weak": {
       "value": "#FFF1DB"
     },
+    "background-outline-hover": {
+      "value": "#EBEDFF"
+    },
     "background-decorative-strong": {
       "value": "#C8F0EF"
     },

--- a/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
+++ b/packages/theme/src/__tests__/__snapshots__/theme.test.tsx.snap
@@ -41,6 +41,7 @@ Object {
     "colorBackgroundError": "#FEF2F2",
     "colorBackgroundInfo": "#EBEDFF",
     "colorBackgroundLinkVisited": "#F5EEFA",
+    "colorBackgroundOutlineHover": "#EBEDFF",
     "colorBackgroundPreview": "linear-gradient(360deg, rgba(71, 94, 105, 0.08) 6.19%, rgba(71, 94, 105, 0.0504167) 57.3%, rgba(255, 255, 255, 0) 93.81%)",
     "colorBackgroundPrimary": "#102EE9",
     "colorBackgroundPrimaryStrong": "#0B1F9C",


### PR DESCRIPTION
## Description of the change
- Add a token to change the outline button background color on hover

## Testing the change
- [ ] Write your testing instructions here

## Type of change
- [x] Non-Breaking Change (change to existing functionality)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
