### PR TITLE
Fix button stylings getting overwritten

### DIFF
--- a/.changeset/funny-ears-cheer.md
+++ b/.changeset/funny-ears-cheer.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Button] - Be explicit about hover color and text decoration stylings so that it doesn't get overwritten

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -62,6 +62,7 @@ const getButtonVariantStyles = (
         return {
           color: {
             _: "colorIconWeak",
+            hover: "colorIconWeak",
             disabled: "colorIconWeaker",
           },
           backgroundColor: {
@@ -86,6 +87,7 @@ const getButtonVariantStyles = (
       return {
         color: {
           _: "colorTextLink",
+          hover: "colorTextLink",
           disabled: "colorText",
         },
         borderWidth: "borderWidth10",
@@ -122,6 +124,7 @@ const getButtonVariantStyles = (
       return {
         color: {
           _: "colorTextLink",
+          hover: "colorTextLink",
           disabled: "colorText",
         },
         borderWidth: "borderWidth10",
@@ -136,7 +139,7 @@ const getButtonVariantStyles = (
     default: {
       return {
         borderWidth: "borderWidth10",
-        color: "colorTextInverse",
+        color: { _: "colorTextInverse", hover: "colorTextInverse" },
         backgroundColor: {
           _: "colorBackgroundPrimary",
           active: "colorBackgroundPrimary",
@@ -268,7 +271,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           outlineStyle={{ focus: "borderStyleSolid" }}
           outlineWidth={{ active: "borderWidth0", focus: "borderWidth20" }}
           ref={ref}
-          textDecoration="none"
+          textDecoration={{ _: "none", hover: "none" }}
           transition="background-color 100ms ease-in, border-color 100ms ease-in"
           w={fullWidth ? "100%" : "auto"}
           {...getButtonPadding(size, iconOnly, !!leadingIcon, !!trailingIcon)}


### PR DESCRIPTION
## Description of the change

The Button as Link's color and text decoration was getting overwritten on hover by other conflicting design systems. This makes those styles explicit so that this doesn't happen.

Issue:
<img width="215" alt="image" src="https://user-images.githubusercontent.com/3478163/231524051-ab80abc7-bea6-4e6d-8eb3-118aed35a143.png">


## Testing the change

- [ ] Check the Button story to make sure styles still look right

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
