### PR TITLE
fix: show upload button in case of error

### DIFF
--- a/.changeset/serious-avocados-invent.md
+++ b/.changeset/serious-avocados-invent.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[FileUploader] Fix: Remove IconTrash button when file uploader has an error

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -130,7 +130,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
               disabled,
               style: { alignSelf: "start" },
             })}
-          {(status === "error" || status === "success") && (
+          {status === "success" && (
             <RemoveButton disabled={disabled} onClick={onRemove} />
           )}
           {status === "loading" && <CancelUploadButton onClick={onCancel} />}


### PR DESCRIPTION
## Description of the change
In case of error the component was showing the trash icon instead of the upload button.
![image](https://user-images.githubusercontent.com/1165437/232803513-52948bbd-08e3-4ffb-b149-5acec4ebeacd.png)

## Type of change

- Bug fix (non-breaking change that fixes an issue)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
