### PR TITLE
Revert "fix: show upload button in case of error"

### DIFF
--- a/.changeset/serious-avocados-invent.md
+++ b/.changeset/serious-avocados-invent.md
@@ -1,5 +1,0 @@
----
-"@localyze-pluto/components": patch
----
-
-[FileUploader] Fix: Remove IconTrash button when file uploader has an error

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -130,7 +130,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
               disabled,
               style: { alignSelf: "start" },
             })}
-          {status === "success" && (
+          {(status === "error" || status === "success") && (
             <RemoveButton disabled={disabled} onClick={onRemove} />
           )}
           {status === "loading" && <CancelUploadButton onClick={onCancel} />}


### PR DESCRIPTION
Reverts Localitos/pluto#763

* The changes were made to validation errors. But we realized that the current behavior is only specific for uploading errors. So, we need to discuss before with the Designers if we want the same view for both cases. 