### PR TITLE
feat(components): add controlled RadioGroup, enforce Radio margin

### DIFF
--- a/.changeset/heavy-bottles-eat.md
+++ b/.changeset/heavy-bottles-eat.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add controlled RadioGroup, enforce Radio component to have margin-bottom zero

--- a/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.test.tsx
+++ b/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import React from "react";
+import UserEvent from "@testing-library/user-event";
+import { Radio } from "../Radio";
+import { ControlledRadioGroup } from "./ControlledRadioGroup";
+
+const Controlled = ({
+  onSubmit,
+}: {
+  onSubmit: (data: { station: string }) => void;
+}) => {
+  const { control, handleSubmit } = useForm({
+    defaultValues: {
+      station: "one",
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit((data) => onSubmit(data))}>
+      <ControlledRadioGroup
+        control={control}
+        id="radio-group-controlled"
+        name="station"
+      >
+        <Radio label="Station 1" value="one" />
+        <Radio label="Station 2" value="two" />
+        <Radio label="Station 3" value="three" />
+      </ControlledRadioGroup>
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+describe("<ControlledRadioGroup />", () => {
+  it("should work properly using controlled state", async () => {
+    window.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+
+    const user = UserEvent.setup();
+
+    const onSubmit = jest.fn();
+
+    render(<Controlled onSubmit={onSubmit} />);
+
+    const radios = await screen.findAllByRole("radio");
+
+    expect(radios[0]).toHaveAttribute("data-state", "checked");
+
+    await user.click(screen.getByText("Station 2"));
+    expect(radios[1]).toHaveAttribute("data-state", "checked");
+
+    await user.click(screen.getByText("Submit"));
+
+    expect(onSubmit).toHaveBeenCalledWith({ station: "two" });
+  });
+});

--- a/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.tsx
+++ b/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Control, Controller } from "react-hook-form";
 import { RadioGroup, RadioGroupProps } from "../RadioGroup";
 
-export interface ControlledRadioGroupProps extends RadioGroupProps {
+export interface ControlledRadioGroupProps
+  extends Omit<RadioGroupProps, "onValueChange" | "value"> {
   /** The name of the group. Submitted with its owning form as part of a name/value pair. */
   name: string;
   /** Invoked with `useForm`. Set to any to allow `any` number of form inputs. */

--- a/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.tsx
+++ b/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Control, Controller } from "react-hook-form";
+import { RadioGroup, RadioGroupProps } from "../RadioGroup";
+
+export interface ControlledRadioGroupProps extends RadioGroupProps {
+  /** The name of the group. Submitted with its owning form as part of a name/value pair. */
+  name: string;
+  /** Invoked with `useForm`. Set to any to allow `any` number of form inputs. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control?: Control<any>;
+}
+
+const ControlledRadioGroup = React.forwardRef<
+  HTMLDivElement,
+  ControlledRadioGroupProps
+>(({ children, name, control, ...props }) => {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange, value } }) => (
+        <RadioGroup
+          name={name}
+          onValueChange={onChange}
+          value={value as string}
+          {...props}
+        >
+          {children}
+        </RadioGroup>
+      )}
+    />
+  );
+});
+
+ControlledRadioGroup.displayName = "ControlledRadioGroup";
+
+export { ControlledRadioGroup };

--- a/packages/components/src/components/Radio/Radio.stories.tsx
+++ b/packages/components/src/components/Radio/Radio.stories.tsx
@@ -2,8 +2,10 @@ import type { ComponentMeta } from "@storybook/react";
 import { useForm, Controller, SubmitHandler } from "react-hook-form";
 import React from "react";
 import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
 import { Radio } from "./Radio";
 import { RadioGroup } from "./RadioGroup";
+import { ControlledRadioGroup } from "./ControlledRadioGroup/ControlledRadioGroup";
 
 export default {
   component: Radio,
@@ -93,5 +95,35 @@ export const WithReactHookForm = (): JSX.Element => {
         </Box.form>
       )}
     />
+  );
+};
+
+export const AsControlledRadioGroup = (): JSX.Element => {
+  const { control, handleSubmit } = useForm({
+    defaultValues: {
+      radio: "default",
+    },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
+    >
+      <ControlledRadioGroup
+        control={control}
+        id="radio-group-controlled"
+        name="radio"
+      >
+        <Radio label="Default" value="default" />
+        <Radio label="Secondary" value="secondary" />
+        <Radio label="Third Option" value="third option" />
+      </ControlledRadioGroup>
+
+      <Box.div marginTop="space40">
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </form>
   );
 };

--- a/packages/components/src/components/Radio/Radio.stories.tsx
+++ b/packages/components/src/components/Radio/Radio.stories.tsx
@@ -127,3 +127,12 @@ export const AsControlledRadioGroup = (): JSX.Element => {
     </form>
   );
 };
+
+AsControlledRadioGroup.parameters = {
+  docs: {
+    description: {
+      story:
+        "If you want to use the RadioGroup with [React Hook Form](https://react-hook-form.com/), use the ControlledRadioGroup component instead.",
+    },
+  },
+};

--- a/packages/components/src/components/Radio/Radio.tsx
+++ b/packages/components/src/components/Radio/Radio.tsx
@@ -95,6 +95,7 @@ const Radio = React.forwardRef<HTMLButtonElement, RadioProps>(
           fontWeight="fontWeightRegular"
           htmlFor={radioID}
           lineHeight="lineHeight20"
+          margin="space0"
         >
           {label}
         </Text.label>

--- a/packages/components/src/components/Radio/index.ts
+++ b/packages/components/src/components/Radio/index.ts
@@ -1,2 +1,3 @@
 export * from "./Radio";
 export * from "./RadioGroup";
+export * from "./ControlledRadioGroup/ControlledRadioGroup";


### PR DESCRIPTION
## Description of the change
- Add a controlled Radio Group
- Enforces Radio component to have margin bottom zero

## Testing the change
RadioGroup can be used with React Hook Form by passing a `control` variable not needing to handle values outside of it

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
