### PR TITLE
fix(components): remove unnecessary forwardRef from ControlledRadioGroup

### DIFF
--- a/.changeset/four-shrimps-run.md
+++ b/.changeset/four-shrimps-run.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Remove unnecessary forwardRef from ControlledRadioGroup

--- a/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.tsx
+++ b/packages/components/src/components/Radio/ControlledRadioGroup/ControlledRadioGroup.tsx
@@ -11,10 +11,12 @@ export interface ControlledRadioGroupProps
   control?: Control<any>;
 }
 
-const ControlledRadioGroup = React.forwardRef<
-  HTMLDivElement,
-  ControlledRadioGroupProps
->(({ children, name, control, ...props }) => {
+export const ControlledRadioGroup = ({
+  children,
+  name,
+  control,
+  ...props
+}: ControlledRadioGroupProps): JSX.Element => {
   return (
     <Controller
       control={control}
@@ -31,8 +33,4 @@ const ControlledRadioGroup = React.forwardRef<
       )}
     />
   );
-});
-
-ControlledRadioGroup.displayName = "ControlledRadioGroup";
-
-export { ControlledRadioGroup };
+};


### PR DESCRIPTION
## Description of the change
Write out a good description of the change. A screenshot or video will also be helpful.
- Since ControlledRadioGroup is not using the passed ref I'm removing it

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
