### PR TITLE
fix: only render select items when open

### DIFF
--- a/.changeset/nine-carrots-fix.md
+++ b/.changeset/nine-carrots-fix.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Select - Renders select options only when open

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -226,14 +226,15 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           </Box.div>
         </Box.button>
         <SelectPopover state={select}>
-          {map(items, (item) => (
-            <SelectItem
-              disabled={item.disabled}
-              key={item.value}
-              label={item.label}
-              value={item.value}
-            />
-          ))}
+          {select.open &&
+            map(items, (item) => (
+              <SelectItem
+                disabled={item.disabled}
+                key={item.value}
+                label={item.label}
+                value={item.value}
+              />
+            ))}
         </SelectPopover>
       </>
     );


### PR DESCRIPTION
## Description of the change

We were rendering all the select items even when the menu isn't open which causes performance issues when there's a lot of items.

This only renders the select items when the popover is open to help with this.

## Testing the change

- [ ] Check out the Select stories to make sure everything still works as expected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
