### PR TITLE
fix: change tab z-index to not be hidden when there is background

### DIFF
--- a/.changeset/nine-socks-matter.md
+++ b/.changeset/nine-socks-matter.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Change z-index on tabs list to be positive so does not get hidden by background

--- a/packages/components/src/components/Tabs/Tab.tsx
+++ b/packages/components/src/components/Tabs/Tab.tsx
@@ -57,7 +57,9 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
         paddingLeft="space40"
         paddingRight="space40"
         paddingTop="space20"
+        position="relative"
         textDecoration="none"
+        zIndex="zIndex10"
         {...props}
         ref={ref}
       >

--- a/packages/components/src/components/Tabs/TabList.tsx
+++ b/packages/components/src/components/Tabs/TabList.tsx
@@ -27,6 +27,7 @@ const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
         {...props}
         ref={ref}
       >
+        {children}
         {withDivider && (
           <Box.div
             backgroundColor="colorBorderWeaker"
@@ -37,7 +38,6 @@ const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
             zIndex="zIndex0"
           />
         )}
-        {children}
       </Box.div>
     );
   }

--- a/packages/components/src/components/Tabs/TabList.tsx
+++ b/packages/components/src/components/Tabs/TabList.tsx
@@ -27,8 +27,6 @@ const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
         {...props}
         ref={ref}
       >
-        {children}
-
         {withDivider && (
           <Box.div
             backgroundColor="colorBorderWeaker"
@@ -36,9 +34,10 @@ const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
             h="1px"
             position="absolute"
             w="100%"
-            zIndex="zIndexNegative1"
+            zIndex="zIndex0"
           />
         )}
+        {children}
       </Box.div>
     );
   }


### PR DESCRIPTION
## Description of the change
Write out a good description of the change. A screenshot or video will also be helpful.
- z-index negative does not work well in pages that has a background (not transparent) and the divider was hidden in some places

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
