### PR TITLE
feat(components): add onClick to file uploader name

### DIFF
--- a/.changeset/red-flies-dress.md
+++ b/.changeset/red-flies-dress.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add onLabelClick property to FileUploader component

--- a/packages/components/src/components/FileUploader/FileUploader.test.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.test.tsx
@@ -29,6 +29,21 @@ describe("<FileUploader />", () => {
     expect(screen.getByRole("button", { name: "Upload" })).toBeInTheDocument();
   });
 
+  it("calls onLabelClick when file title is clicked", async () => {
+    const onLabelClickSpy = jest.fn();
+    renderFileUploader({
+      label: "CV",
+      maxFileSize: "2MB",
+      onLabelClick: onLabelClickSpy,
+    });
+
+    const label = screen.getByText("CV");
+    expect(label).toBeInTheDocument();
+    await userEvent.click(label);
+
+    expect(onLabelClickSpy).toHaveBeenCalled();
+  });
+
   describe('when state is "loading"', () => {
     const FILE_LABEL = "Passport scan";
     const FILE_NAME = "my_file_name.pdf";
@@ -125,6 +140,24 @@ describe("<FileUploader />", () => {
 
       expect(mockOnRemove).toHaveBeenCalled();
     });
+  });
+
+  it("calls onLabelClick when file title anchor is clicked", async () => {
+    const onLabelClickSpy = jest.fn();
+    renderFileUploader({
+      label: "Personal Document",
+      maxFileSize: "2MB",
+      fileUrl: FILE_URL,
+      fileSize: "1MB",
+      progress: 100,
+      onLabelClick: onLabelClickSpy,
+    });
+
+    const anchor = screen.getByRole("link", { name: "Personal Document" });
+    expect(anchor).toBeInTheDocument();
+    await userEvent.click(anchor);
+
+    expect(onLabelClickSpy).toHaveBeenCalled();
   });
 
   describe("when there is an error", () => {

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -13,7 +13,7 @@ import { FileUploaderProgressBar } from "./FileUploaderProgressBar";
 import { FileUploaderIcon } from "./FileUploaderIcon";
 
 export interface FileUploaderProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onClick"> {
   /** The title of the file */
   label: string;
 
@@ -46,6 +46,9 @@ export interface FileUploaderProps
 
   /** Disables the file uploader */
   disabled?: boolean;
+
+  /** Handles clicking on file title */
+  onLabelClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 /** Visual component to display status of a file upload */
@@ -63,6 +66,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
       onCancel,
       onRemove,
       disabled = false,
+      onLabelClick,
     },
     ref
   ) => {
@@ -105,7 +109,11 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
               flexGrow={1}
               justifyContent={isMobile ? "top" : "center"}
             >
-              <FileUploaderTitle fileUrl={fileUrl} label={label} />
+              <FileUploaderTitle
+                fileUrl={fileUrl}
+                label={label}
+                onClick={onLabelClick}
+              />
               <Box.div
                 alignItems={{ _: "left", md: "center" }}
                 display="flex"

--- a/packages/components/src/components/FileUploader/FileUploaderTitle.tsx
+++ b/packages/components/src/components/FileUploader/FileUploaderTitle.tsx
@@ -5,16 +5,22 @@ import { Text } from "../../primitives/Text";
 export const FileUploaderTitle = ({
   label,
   fileUrl,
+  onClick,
 }: {
   label: string;
   fileUrl?: string;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }): React.ReactElement => {
   if (fileUrl) {
     return (
-      <Anchor href={fileUrl} target="_blank">
+      <Anchor href={fileUrl} onClick={onClick} target="_blank">
         {label}
       </Anchor>
     );
   }
-  return <Text.span color="colorTextStrongest">{label}</Text.span>;
+  return (
+    <Text.span color="colorTextStrongest" onClick={onClick}>
+      {label}
+    </Text.span>
+  );
 };


### PR DESCRIPTION
## Description of the change

Adds compatibility for ~~onClick~~ onClickLabel handlers in the file name anchor of uploaded files. Due to a change in how we are displaying files that don't yet have a public url we needed this handler to change how we're displaying these files when clicking on the anchor link.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
