### PR TITLE
feat: add building-2, pie-chart, puzzle and wallet as available icons

### DIFF
--- a/.changeset/loud-doors-scream.md
+++ b/.changeset/loud-doors-scream.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Add building-2, pie-chart, puzzle and wallet as available icons

--- a/packages/components/src/components/Icon/LucideIcons.ts
+++ b/packages/components/src/components/Icon/LucideIcons.ts
@@ -1,15 +1,23 @@
 import {
   BaggageClaim,
+  Building2,
   HeartHandshake,
   Palette,
+  PieChart,
+  Puzzle,
   Slack,
+  Wallet,
   Icon,
 } from "lucide-react";
 import { LucideIconName } from "./types/LucideIconName";
 
 export const LucideIcons: Record<LucideIconName, Icon> = {
   "baggage-claim": BaggageClaim,
+  "building-2": Building2,
   "heart-handshake": HeartHandshake,
   palette: Palette,
   slack: Slack,
+  "pie-chart": PieChart,
+  puzzle: Puzzle,
+  wallet: Wallet,
 };

--- a/packages/components/src/components/Icon/types/LucideIconName.ts
+++ b/packages/components/src/components/Icon/types/LucideIconName.ts
@@ -1,5 +1,9 @@
 export type LucideIconName =
   | "baggage-claim"
+  | "building-2"
   | "heart-handshake"
   | "palette"
-  | "slack";
+  | "pie-chart"
+  | "puzzle"
+  | "slack"
+  | "wallet";


### PR DESCRIPTION
## Description of the change
- Add some Lucide icons to the list of available icons

## Type of change
- [x] Non-Breaking Change (change to existing functionality)

