### PR TITLE
feat: support custom icon with callout component

### DIFF
--- a/.changeset/modern-experts-attend.md
+++ b/.changeset/modern-experts-attend.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Callout] - Can now use any supported icon

--- a/packages/components/src/components/Callout/Callout.stories.tsx
+++ b/packages/components/src/components/Callout/Callout.stories.tsx
@@ -60,3 +60,10 @@ WithoutBackground.args = {
   children: "This is an callout without background.",
   withoutBackground: true,
 };
+
+export const WithCustomIcon = Template.bind({});
+WithCustomIcon.args = {
+  children: "This is an info message with a custom icon.",
+  variant: "information",
+  icon: "FireIcon",
+};

--- a/packages/components/src/components/Callout/Callout.tsx
+++ b/packages/components/src/components/Callout/Callout.tsx
@@ -2,6 +2,7 @@ import { SystemProp, Theme } from "@xstyled/styled-components";
 import React from "react";
 import { Box } from "../../primitives/Box";
 import { Icon, IconProps } from "../Icon";
+import { IconName } from "../Icon/types/IconName";
 
 type CalloutVariantOptions = "error" | "information" | "success" | "warning";
 
@@ -15,6 +16,9 @@ export interface CalloutProps
 
   /** Show or hide the callout background */
   withoutBackground?: boolean;
+
+  /** Overrides default icon for variant */
+  icon?: IconName;
 }
 
 const getVariantProps = (
@@ -124,9 +128,17 @@ const getContentVariantProps = (
 /** A callout is a bar used to give user information. */
 const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
   (
-    { variant = "information", children, withoutBackground = false, ...props },
+    {
+      variant = "information",
+      children,
+      withoutBackground = false,
+      icon,
+      ...props
+    },
     ref
   ) => {
+    const iconProps = getIconVariantProps(variant);
+
     return (
       <Box.div
         borderRadius="borderRadius20"
@@ -138,9 +150,10 @@ const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
       >
         <Box.span padding="space10">
           <Icon
-            size="sizeIcon20"
-            {...getIconVariantProps(variant)}
+            color={iconProps.color}
             decorative
+            icon={icon || iconProps.icon}
+            size="sizeIcon20"
           />
         </Box.span>
         <Box.span


### PR DESCRIPTION
## Description of the change

This allows use of a custom icon with a variant of the callout component.

<img width="353" alt="Screenshot 2023-06-12 at 11 06 53 AM" src="https://github.com/Localitos/pluto/assets/3478163/fdaea5a7-d545-4a5c-acf6-e7bb68c9a8eb">

## Testing the change

- [ ] Check out the Callout story

## Type of change

- [ ] New feature (non-breaking change that adds functionality)
