### PR TITLE
fix(components): fix docs bug in Tabs and Table components

### DIFF
--- a/.changeset/slimy-hotels-explain.md
+++ b/.changeset/slimy-hotels-explain.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fix storybook docs bug in Tabs and Table

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -17,10 +17,12 @@ import { Table, THead, TBody, Tr, Th, ThButton, Td } from "./index";
 
 const table: Meta<typeof Table> = {
   title: "Components/Table",
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore Table has a required prop which confuses Storybook here.
-  subcomponents: { Table, THead, TBody, Tr, Th, ThButton, Td },
-  component: Table,
+  args: {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Table has a required prop which confuses Storybook here.
+    subcomponents: { Table, THead, TBody, Tr, Th, ThButton, Td },
+    component: Table,
+  },
 };
 
 export default table;

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta } from "@storybook/react";
+import type { Meta } from "@storybook/react";
 import React from "react";
 import { Box } from "../../primitives/Box";
 import { Heading } from "../Heading";
@@ -9,13 +9,17 @@ import { TabPanels } from "./TabPanels";
 import { TabPanel } from "./TabPanel";
 import { Tab } from "./Tab";
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore TabList has a required prop which confuses Storybook here.
-export default {
-  component: Tabs,
-  subcomponents: { Tab, TabList, TabPanels, TabPanel },
+const tabs: Meta<typeof Tabs> = {
   title: "Components/Tabs",
-} as ComponentMeta<typeof Tabs>;
+  args: {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Table has a required prop which confuses Storybook here.
+    subcomponents: { Tab, TabList, TabPanels, TabPanel },
+    component: Tabs,
+  },
+};
+
+export default tabs;
 
 export const Default = (): JSX.Element => {
   return (


### PR DESCRIPTION
## Description of the change

The way were doing the args in the Table and Tabs components was outdated, so I updated the component docs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![Screenshot 2023-06-13 at 14 32 03](https://github.com/Localitos/pluto/assets/52461415/835445cd-a903-41d4-a8cb-07e96cf48af8)


After:
![Screenshot 2023-06-13 at 14 35 04](https://github.com/Localitos/pluto/assets/52461415/f667c041-842b-49d1-a764-6d6dba6c3f31)
![Screenshot 2023-06-13 at 14 35 13](https://github.com/Localitos/pluto/assets/52461415/7badbc69-f583-4f06-94b0-022f6e2b0450)
