### PR TITLE
fix: change lint script, fix lint errors on Dropzone and ModalBody

### DIFF
--- a/.changeset/chilly-spiders-cry.md
+++ b/.changeset/chilly-spiders-cry.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fix eslint configuration, fix lint errors on Dropzone and ModalBody

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.eslintrc.js
+jest.config.js
+packages/browserslist-config/index.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "turbo clean && rm -rf node_modules",
     "dev": "turbo dev --no-cache --parallel --continue",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "lint": "turbo lint",
+    "lint": "eslint packages",
     "prepare": "husky install",
     "release": "turbo build && changeset publish",
     "start": "storybook dev -p 6006",

--- a/packages/components/src/components/Dropzone/Dropzone.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import type { SystemProp, Theme } from "@xstyled/styled-components";
 import map from "lodash/map";
-import { FileWithPath, useDropzone } from "react-dropzone";
+import { FileError, FileWithPath, useDropzone } from "react-dropzone";
 import forEach from "lodash/forEach";
 import { Text } from "../../primitives/Text";
 import { ProgressBar } from "../ProgressBar";
@@ -17,7 +17,7 @@ import { DropzoneCancelUploadButton } from "./DropzoneCancelUploadButton";
 export type FileTypes = Record<string, string[]>;
 
 export type DropzoneProps = {
-  /** This is the function that gets triggered when a file is dropped */
+  /** This is the function that gets triggered when a file is dropped AHOY */
   onDrop: (files: FileWithPath[]) => void;
   /** This is the function that gets triggered when the cancel button is clicked */
   onCancel: (files: FileWithPath[]) => void;
@@ -105,6 +105,24 @@ const getIcon = (
 const getFileTypeErrorMessage = (fileTypes: FileTypes) =>
   `Wrong file type. ${getFileExtensions(fileTypes)} format only.`;
 
+const onError = (
+  err: FileError,
+  setDropZoneErrors: (error: string) => void,
+  tooManyFilesError: string,
+  maxFileSize: number | undefined,
+  fileTypes: FileTypes
+) => {
+  if (err.code === "too-many-files") {
+    setDropZoneErrors(tooManyFilesError);
+  }
+  if (err.code === "file-too-large" && maxFileSize) {
+    setDropZoneErrors(`File must be less than ${formatBytes(maxFileSize)}.`);
+  }
+  if (err.code === "file-invalid-type") {
+    setDropZoneErrors(getFileTypeErrorMessage(fileTypes));
+  }
+};
+
 const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
   (
     {
@@ -158,17 +176,13 @@ const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
       onDropRejected: (fileRejections) => {
         forEach(fileRejections, (file) => {
           forEach(file.errors, (err) => {
-            if (err.code === "too-many-files") {
-              setDropZoneErrors(tooManyFilesError);
-            }
-            if (err.code === "file-too-large" && maxFileSize) {
-              setDropZoneErrors(
-                `File must be less than ${formatBytes(maxFileSize)}.`
-              );
-            }
-            if (err.code === "file-invalid-type") {
-              setDropZoneErrors(getFileTypeErrorMessage(fileTypes));
-            }
+            onError(
+              err,
+              setDropZoneErrors,
+              tooManyFilesError,
+              maxFileSize,
+              fileTypes
+            );
           });
         });
       },

--- a/packages/components/src/components/Dropzone/Dropzone.tsx
+++ b/packages/components/src/components/Dropzone/Dropzone.tsx
@@ -17,7 +17,7 @@ import { DropzoneCancelUploadButton } from "./DropzoneCancelUploadButton";
 export type FileTypes = Record<string, string[]>;
 
 export type DropzoneProps = {
-  /** This is the function that gets triggered when a file is dropped AHOY */
+  /** This is the function that gets triggered when a file is dropped */
   onDrop: (files: FileWithPath[]) => void;
   /** This is the function that gets triggered when the cancel button is clicked */
   onCancel: (files: FileWithPath[]) => void;

--- a/packages/components/src/components/Modal/ModalBody.tsx
+++ b/packages/components/src/components/Modal/ModalBody.tsx
@@ -16,7 +16,7 @@ const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
   ({ children, disableOverflow, padding = "space60", ...props }, ref) => {
     return (
       <Box.div
-        overflowY={!disableOverflow ? "auto" : undefined}
+        overflowY={disableOverflow ? undefined : "auto"}
         padding={padding}
         ref={ref}
         {...props}


### PR DESCRIPTION
## Description of the change
- `yarn lint` locally runs `turbo lint` but on actions is eslint who is running. This PR changes it
- Fix lint errors on Dropzone and ModalBody
- Add eslintignore to ignore some files

## Testing the change
- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
