### PR TITLE
fix: add act function to Radio component test

### DIFF
--- a/.changeset/many-monkeys-impress.md
+++ b/.changeset/many-monkeys-impress.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fix warning on Radio component test

--- a/packages/components/src/components/Radio/Radio.test.tsx
+++ b/packages/components/src/components/Radio/Radio.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Radio } from "./Radio";
 import { RadioGroup } from "./RadioGroup";
@@ -45,9 +45,11 @@ describe("Radio", () => {
         <Radio id="default" label="Default" value="default" />
       </RadioGroup>
     );
-    const renderedRadio = screen.getByRole("radio");
 
-    await user.click(renderedRadio);
+    const renderedRadio = await screen.findByRole("radio");
+
+    await act(async () => user.click(renderedRadio));
+
     expect(renderedRadio).toBeChecked();
     expect(renderedRadio).toHaveAttribute("data-state", "checked");
   });


### PR DESCRIPTION
## Description of the change
- After React 18 update this test is emitting warnings (with others). This PR adds an `act` to remove the warning

before:
![Screen Shot 2023-06-20 at 10 21 50](https://github.com/Localitos/pluto/assets/2047941/9c63db07-89bc-4217-8a87-e3a0d08f0473)

after:
![Screen Shot 2023-06-20 at 10 21 35](https://github.com/Localitos/pluto/assets/2047941/9557a184-f42a-4bd4-9236-6cb52580a84d)


## Testing the change
- Run tests locally

## Type of change
- [x] Non-Breaking Change (change to existing functionality)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
