### PR TITLE
fix(components): Replace renderHook by the correct version after React update

### DIFF
--- a/.changeset/thirty-ghosts-impress.md
+++ b/.changeset/thirty-ghosts-impress.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fix error related to ReactDom.render while running tests

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,6 @@
     "@localyze-pluto/tsconfig": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^28.1.4",
     "@types/react": "^17.0.2",

--- a/packages/components/src/components/Avatar/useGetImageOrientation.test.ts
+++ b/packages/components/src/components/Avatar/useGetImageOrientation.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook, waitFor } from "@testing-library/react";
 import * as imageOrientation from "./getImageOrientation";
 import { useGetImageOrientation } from "./useGetImageOrientation";
 
@@ -7,25 +7,27 @@ describe("useGetImageOrientation", () => {
     jest
       .spyOn(imageOrientation, "getImageOrientation")
       .mockResolvedValue("portrait");
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useGetImageOrientation("/path-to-file.jpg")
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.orientation).toBe("portrait");
     expect(result.current.hasError).toBeFalsy();
+
+    await waitFor(() => {
+      expect(result.current.orientation).toBe("portrait");
+    });
   });
 
   it("should return error", async () => {
     jest.spyOn(imageOrientation, "getImageOrientation").mockRejectedValue(null);
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useGetImageOrientation("/path-to-file.jpg")
     );
 
-    await waitForNextUpdate();
-
     expect(result.current.orientation).toBeUndefined();
-    expect(result.current.hasError).toBeTruthy();
+
+    await waitFor(() => {
+      expect(result.current.hasError).toBeTruthy();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4337,14 +4337,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@^12.1.5":
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
@@ -12530,13 +12522,6 @@ react-element-to-jsx-string@^15.0.0:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "18.1.0"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"


### PR DESCRIPTION
## Description of the change
- Fix ReactDom.render error by importing renderHook correctly after React update

BEFORE:

![Screen Shot 2023-06-21 at 08 53 59](https://github.com/Localitos/pluto/assets/2047941/be22a35d-057d-454f-b7fa-a2620dd39dc2)

AFTER:

![Screen Shot 2023-06-21 at 08 51 26](https://github.com/Localitos/pluto/assets/2047941/0c0f441e-2660-4f47-a885-90be286a2537)


## Type of change
- [x] Non-Breaking Change (change to existing functionality)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
