### PR TITLE
feat(components): Add delete confirmation dialog before file removing from FileUploader

### DIFF
--- a/.changeset/moody-trains-rush.md
+++ b/.changeset/moody-trains-rush.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Add a deleteWithConfirmation prop to FileUploader waiting for user to confirm file deletion

--- a/packages/components/src/components/FileUploader/ConfirmationDialog.tsx
+++ b/packages/components/src/components/FileUploader/ConfirmationDialog.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { DisclosureState } from "ariakit";
+import {
+  AlertDialog,
+  AlertDialogIconWrapper,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+} from "../AlertDialog";
+import { Button } from "../Button";
+import { Paragraph } from "../Paragraph";
+import { Icon } from "../Icon";
+
+export const ConfirmationDialog = ({
+  state,
+  onConfirm,
+  onCancel,
+}: {
+  state: DisclosureState;
+  onConfirm: () => void;
+  onCancel: () => void;
+}): JSX.Element => {
+  return (
+    <AlertDialog centered state={state}>
+      <AlertDialogIconWrapper>
+        <Icon
+          color="colorIconError"
+          decorative
+          icon="XCircleIcon"
+          size="sizeIcon40"
+        />
+      </AlertDialogIconWrapper>
+      <AlertDialogHeader>Delete document</AlertDialogHeader>
+      <AlertDialogBody>
+        <Paragraph marginBottom="space0" size="large">
+          Are you sure you want to delete this document? This action cannot be
+          undone.
+        </Paragraph>
+      </AlertDialogBody>
+      <AlertDialogFooter>
+        <Button onClick={onCancel} variant="secondary">
+          Cancel
+        </Button>
+        <Button onClick={onConfirm} variant="destructive">
+          Delete
+        </Button>
+      </AlertDialogFooter>
+    </AlertDialog>
+  );
+};

--- a/packages/components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.stories.tsx
@@ -1,6 +1,7 @@
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import React, { useState } from "react";
 import Uppy from "@uppy/core";
+import noop from "lodash/noop";
 import { Button } from "../Button";
 import { FileUploader } from "./FileUploader";
 import { FileUploaderButton } from "./FileUploaderButton";
@@ -319,4 +320,32 @@ WithRequiredButton.parameters = {
         "If you want to use required property on the FileUploaderButton to allow form submissions only with filled data.",
     },
   },
+};
+
+export const WithRemoveConfirmation = (): React.ReactElement => {
+  const [fileInformation, setFileInformation] = useState<{
+    fileName: string;
+    fileSize: string;
+    fileUrl?: string;
+  } | null>({
+    fileName: "employment.pdf",
+    fileSize: "128",
+    fileUrl: FILE_URL,
+  });
+
+  return (
+    <FileUploader
+      deleteWithConfirmation
+      label="Employment Contract"
+      {...fileInformation}
+      maxFileSize="2MB"
+      onRemove={() => {
+        setFileInformation(null);
+      }}
+    >
+      <FileUploaderButton id="my-uploader" onChange={noop} variant="secondary">
+        Upload
+      </FileUploaderButton>
+    </FileUploader>
+  );
 };

--- a/packages/components/src/components/FileUploader/FileUploader.test.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { FileUploader, FileUploaderProps } from "./FileUploader";
@@ -195,5 +195,65 @@ describe("<FileUploader />", () => {
     const uploadButton = screen.getByRole("button", { name: "Upload" });
     expect(uploadButton).toBeInTheDocument();
     expect(uploadButton).toBeDisabled();
+  });
+
+  describe("when deleteWithConfirmation is true", () => {
+    it("shows a Dialog before deleting a file calling onRemove only if user confirms it", async () => {
+      const mockOnRemove = jest.fn();
+      renderFileUploader({
+        label: "Visa",
+        maxFileSize: "2MB",
+        fileUrl: FILE_URL,
+        fileSize: "1MB",
+        progress: 100,
+        onRemove: mockOnRemove,
+        deleteWithConfirmation: true,
+      });
+      const removeButton = await screen.findByRole("button", {
+        name: "Remove file",
+      });
+
+      await act(async () => await userEvent.click(removeButton));
+
+      await waitFor(async () => {
+        expect(await screen.findByText("Delete document")).toBeInTheDocument();
+      });
+
+      const deleteButton = await screen.findByRole("button", {
+        name: "Delete",
+      });
+
+      await act(async () => await userEvent.click(deleteButton));
+      expect(mockOnRemove).toHaveBeenCalled();
+    });
+
+    it("shows a Dialog before deleting a file but does not call onRemove if user cancel it", async () => {
+      const mockOnRemove = jest.fn();
+      renderFileUploader({
+        label: "Visa",
+        maxFileSize: "2MB",
+        fileUrl: FILE_URL,
+        fileSize: "1MB",
+        progress: 100,
+        onRemove: mockOnRemove,
+        deleteWithConfirmation: true,
+      });
+      const removeButton = await screen.findByRole("button", {
+        name: "Remove file",
+      });
+
+      await act(async () => await userEvent.click(removeButton));
+
+      await waitFor(async () => {
+        expect(await screen.findByText("Delete document")).toBeInTheDocument();
+      });
+
+      const cancelButton = await screen.findByRole("button", {
+        name: "Cancel",
+      });
+
+      await act(async () => await userEvent.click(cancelButton));
+      expect(mockOnRemove).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Description of the change
Write out a good description of the change. A screenshot or video will also be helpful.
- Add `deleteWithConfirmation` prop to FileUploader
- Add a confirmation dialog to FileUploader to be shown when deleteWithConfirmation is true and user removes a file

![Screen Shot 2023-07-05 at 14 53 23](https://github.com/Localitos/pluto/assets/2047941/53506c84-83eb-4ac2-bb60-cb4b1c518aa4)


## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
