### PR TITLE
fix: fix modal subheading spacing

### DIFF
--- a/packages/components/src/components/Modal/ModalSubHeading.tsx
+++ b/packages/components/src/components/Modal/ModalSubHeading.tsx
@@ -14,13 +14,14 @@ const ModalSubHeading = React.forwardRef<
   ModalSubHeadingProps
 >(({ children, ...props }, ref) => {
   return (
-    <Box.div marginTop="space10">
+    <Box.div marginTop="space50">
       <Text.h3
         color="colorText"
         fontFamily="fontFamilyModerat"
         fontSize="fontSize20"
         fontWeight="fontWeightRegular"
         lineHeight="lineHeight20"
+        marginTop="space0"
         ref={ref}
         {...props}
       >


### PR DESCRIPTION
## Description of the change

The margin top for the Modal subheading could be different than what you're seeing in Storybook because the CSS was not getting reset in Storybook and the browser was inserting margin for the `h3` element. This explicitly sets the margin top for consistent spacing.

Thanks to @rssilva and @BrianLincoln who figured out the cause of the issue!

## Testing the change

- [ ] Try using the ModalSubHeading in another repo

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)

