### PR TITLE
Turn off capitalized comments eslint rule

### DIFF
--- a/.changeset/rare-poems-join.md
+++ b/.changeset/rare-poems-join.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/eslint-config": minor
+---
+
+[Eslint] - Turn off capitalized comments eslint rule

--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
     "no-console": ["error"],
     "prefer-template": ["error"],
     "no-use-before-define": ["error"],
-    "capitalized-comments": ["error"],
+    "capitalized-comments": ["off"],
     "import/prefer-default-export": "off",
     "import/no-default-export": "error",
     "import/order": [


### PR DESCRIPTION
## Description of the change

Turns off capitalized comments eslint rule which was more annoying in cases when you're temporarily commenting out code

## Type of change

- [ ] Non-Breaking Change (change to existing functionality)