### PR TITLE
chore(design-tokens): add icons sizes from 80 to 160

### DIFF
--- a/.changeset/tender-plums-think.md
+++ b/.changeset/tender-plums-think.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/design-tokens": patch
+"@localyze-pluto/components": patch
+"@localyze-pluto/theme": patch
+---
+
+Adds icon size tokens from 80 to 160

--- a/packages/design-tokens/src/tokens/size.tokens.json
+++ b/packages/design-tokens/src/tokens/size.tokens.json
@@ -27,6 +27,42 @@
     "icon-70": {
       "value": "2.25rem",
       "comment": "36px"
+    },
+    "icon-80": {
+      "value": "2.5rem",
+      "comment": "40px"
+    },
+    "icon-90": {
+      "value": "2.75rem",
+      "comment": "44px"
+    },
+    "icon-100": {
+      "value": "3rem",
+      "comment": "48px"
+    },
+    "icon-110": {
+      "value": "3.25rem",
+      "comment": "52px"
+    },
+    "icon-120": {
+      "value": "3.5rem",
+      "comment": "56px"
+    },
+    "icon-130": {
+      "value": "3.75rem",
+      "comment": "60px"
+    },
+    "icon-140": {
+      "value": "4rem",
+      "comment": "64px"
+    },
+    "icon-150": {
+      "value": "4.25rem",
+      "comment": "68px"
+    },
+    "icon-160": {
+      "value": "4.5rem",
+      "comment": "72px"
     }
   }
 }


### PR DESCRIPTION
## Description of the change

Adds additional icon size tokens to support icon sizes from 2.5rem to 4.5rem.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
