### PR TITLE
feat: updates radio and checkbox labels styles

### DIFF
--- a/.changeset/soft-laws-behave.md
+++ b/.changeset/soft-laws-behave.md
@@ -1,0 +1,8 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Radio] and [Checkbox]:
+
+- Removes color red from Radio and Checkbox label when in error state
+- Changes label color to colorTextStrongest

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -167,7 +167,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
           )}
         </StyledCheckbox>
         <Text.label
-          color={error ? "colorTextError" : "colorTextStronger"}
+          color="colorTextStrongest"
           fontSize="fontSize20"
           htmlFor={id}
           lineHeight="lineHeight20"

--- a/packages/components/src/components/Radio/Radio.tsx
+++ b/packages/components/src/components/Radio/Radio.tsx
@@ -89,7 +89,7 @@ const Radio = React.forwardRef<HTMLButtonElement, RadioProps>(
           </Box.span>
         </Box.button>
         <Text.label
-          color={hasError ? "colorTextError" : "colorTextStronger"}
+          color="colorTextStrongest"
           fontFamily="fontFamilyModerat"
           fontSize="fontSize20"
           fontWeight="fontWeightRegular"


### PR DESCRIPTION
## Description of the change

This PR:
* Removes the red color from Radio and Checkbox components in the error state.
* Changes the label color to "colorTextStrongest"

![image](https://github.com/Localitos/pluto/assets/5320963/3674af3c-6ef1-4510-bada-f6df881c6517)

![image](https://github.com/Localitos/pluto/assets/5320963/e9a36319-3ca4-4fc1-a7e1-25f01519e62d)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
