### PR TITLE
feat: add red variant to the Badge component

### DIFF
--- a/.changeset/fuzzy-comics-buy.md
+++ b/.changeset/fuzzy-comics-buy.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add red variant to Badge component

--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -32,6 +32,12 @@ Green.args = {
   color: "green",
 };
 
+export const Red = Template.bind({});
+Red.args = {
+  children: "Red badge",
+  color: "red",
+};
+
 export const Purple = Template.bind({});
 Purple.args = {
   children: "Purple badge",

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -5,7 +5,13 @@ import { Icon } from "../Icon";
 import { IconName } from "../Icon/types/IconName";
 
 type BadgeSizeOptions = "large" | "small";
-type BadgeColorOptions = "blue" | "gray" | "green" | "purple" | "yellow";
+type BadgeColorOptions =
+  | "blue"
+  | "gray"
+  | "green"
+  | "purple"
+  | "red"
+  | "yellow";
 
 export interface BadgeProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {
@@ -48,6 +54,12 @@ const getColorProps = (
       return {
         backgroundColor: "colorBackgroundLinkVisited",
         color: "colorTextLinkVisited",
+      };
+    }
+    case "red": {
+      return {
+        backgroundColor: "colorBackgroundError",
+        color: "colorTextStrongest",
       };
     }
     default: {


### PR DESCRIPTION
## Description of the change
- Add red as a color variant to Badge component

![Screen Shot 2023-09-27 at 19 15 46](https://github.com/Localitos/pluto/assets/2047941/f8ed748d-01e2-4ece-a5de-61b941fa8a21)


## Type of change
- [x] Non-Breaking Change (change to existing functionality)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
