### PR TITLE
feat: add lucid copy icon to list

### DIFF
--- a/.changeset/lovely-gorillas-mix.md
+++ b/.changeset/lovely-gorillas-mix.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Icon] Add Lucid copy Icon to the list

--- a/packages/components/src/components/Icon/LucideIcons.ts
+++ b/packages/components/src/components/Icon/LucideIcons.ts
@@ -10,6 +10,7 @@ import {
   Slack,
   Wallet,
   Icon,
+  Copy,
 } from "lucide-react";
 import { LucideIconName } from "./types/LucideIconName";
 
@@ -24,4 +25,5 @@ export const LucideIcons: Record<LucideIconName, Icon> = {
   "pie-chart": PieChart,
   puzzle: Puzzle,
   wallet: Wallet,
+  copy: Copy,
 };

--- a/packages/components/src/components/Icon/types/LucideIconName.ts
+++ b/packages/components/src/components/Icon/types/LucideIconName.ts
@@ -1,6 +1,7 @@
 export type LucideIconName =
   | "baggage-claim"
   | "building-2"
+  | "copy"
   | "heart-handshake"
   | "mail-question"
   | "palette"


### PR DESCRIPTION
## Description of the change

Adds the "copy" Lucid Icon to our available Icons list

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
