### PR TITLE
feat: add pen-square lucid icon

### DIFF
--- a/.changeset/cold-yaks-cry.md
+++ b/.changeset/cold-yaks-cry.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Icons] Add pen-square lucid icon to the list

--- a/packages/components/src/components/Icon/LucideIcons.ts
+++ b/packages/components/src/components/Icon/LucideIcons.ts
@@ -11,6 +11,7 @@ import {
   Wallet,
   LucideIcon,
   Copy,
+  PenSquare,
 } from "lucide-react";
 import { LucideIconName } from "./types/LucideIconName";
 
@@ -26,4 +27,5 @@ export const LucideIcons: Record<LucideIconName, LucideIcon> = {
   puzzle: Puzzle,
   wallet: Wallet,
   copy: Copy,
+  "pen-square": PenSquare,
 };

--- a/packages/components/src/components/Icon/types/LucideIconName.ts
+++ b/packages/components/src/components/Icon/types/LucideIconName.ts
@@ -5,6 +5,7 @@ export type LucideIconName =
   | "heart-handshake"
   | "mail-question"
   | "palette"
+  | "pen-square"
   | "pie-chart"
   | "puzzle"
   | "save"


### PR DESCRIPTION
## Description of the change

Adds the [PenSquare](https://lucide.dev/icons/pen-square) Icon to our list

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
