### PR TITLE
fix: remove extra space from FormSelect, FormInput, FormTextArea

### DIFF
--- a/.changeset/grumpy-numbers-serve.md
+++ b/.changeset/grumpy-numbers-serve.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[FormSelect] Removes the extra div from component when no helpText is provided
+The extra div makes hard to align the component with other elements
+within the Parent component outside of the Design System

--- a/.changeset/grumpy-numbers-serve.md
+++ b/.changeset/grumpy-numbers-serve.md
@@ -2,6 +2,14 @@
 "@localyze-pluto/components": patch
 ---
 
-[FormSelect] Removes the extra div from component when no helpText is provided
-The extra div makes hard to align the component with other elements
-within the Parent component outside of the Design System
+[FormSelect] Remove the extra div from component when no helpText is provided
+The extra div makes it hard to align the component with other elements
+within the parent component outside of the design system
+
+[FormInput] Remove the extra div from component when no helpText is provided
+The extra div makes it hard to align the component with other elements
+within the parent component outside of the design system
+
+[FormTextArea] Remove the extra div from component when no helpText is provided
+The extra div makes it hard to align the component with other elements
+within the parent component outside of the design system

--- a/packages/components/src/components/FormInput/FormInput.stories.tsx
+++ b/packages/components/src/components/FormInput/FormInput.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React, { useEffect } from "react";
 import { useUID } from "react-uid";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { Box } from "../../primitives/Box";
@@ -132,55 +132,57 @@ export const AsControlledFormInput = (): JSX.Element => {
   const inputID = useUID();
   return (
     <Box.form onSubmit={handleSubmit(onSubmit)}>
-      <ControlledFormInput
-        control={control}
-        data-testid="test"
-        helpText={"Please enter a flavor."}
-        id={`${inputID}-1`}
-        label="Enter a flavor"
-        name="flavor"
-        placeholder="Maybe something crazy?"
-        required
-        size="large"
-        type="text"
-      />
-      <ControlledFormInput
-        control={control}
-        helpText={"Please enter a flavor."}
-        id={`${inputID}-1`}
-        label="Error flavor"
-        name="flavor1"
-        placeholder="Maybe something crazy?"
-        required
-        type="text"
-      />
-      <ControlledFormInput
-        control={control}
-        id={`${inputID}-2`}
-        label="Prefilled flavor"
-        name="flavor2"
-        type="text"
-      />
-      <ControlledFormInput
-        control={control}
-        disabled
-        id={`${inputID}-2`}
-        label="Disabled flavor"
-        name="flavor3"
-        type="text"
-      />
-      <ControlledFormInput
-        control={control}
-        id={`${inputID}-2`}
-        label="Read-Only flavor"
-        name="flavor4"
-        readOnly
-        type="text"
-      />
-      <Box.div>
-        <Button type="submit" variant="primary">
-          Submit
-        </Button>
+      <Box.div display="flex" flexDirection="column" gap="space50">
+        <ControlledFormInput
+          control={control}
+          data-testid="test"
+          helpText={"Please enter a flavor."}
+          id={`${inputID}-1`}
+          label="Enter a flavor"
+          name="flavor"
+          placeholder="Maybe something crazy?"
+          required
+          size="large"
+          type="text"
+        />
+        <ControlledFormInput
+          control={control}
+          helpText={"Please enter a flavor."}
+          id={`${inputID}-1`}
+          label="Error flavor"
+          name="flavor1"
+          placeholder="Maybe something crazy?"
+          required
+          type="text"
+        />
+        <ControlledFormInput
+          control={control}
+          id={`${inputID}-2`}
+          label="Prefilled flavor"
+          name="flavor2"
+          type="text"
+        />
+        <ControlledFormInput
+          control={control}
+          disabled
+          id={`${inputID}-2`}
+          label="Disabled flavor"
+          name="flavor3"
+          type="text"
+        />
+        <ControlledFormInput
+          control={control}
+          id={`${inputID}-2`}
+          label="Read-Only flavor"
+          name="flavor4"
+          readOnly
+          type="text"
+        />
+        <Box.div>
+          <Button type="submit" variant="primary">
+            Submit
+          </Button>
+        </Box.div>
       </Box.div>
     </Box.form>
   );

--- a/packages/components/src/components/FormInput/FormInput.tsx
+++ b/packages/components/src/components/FormInput/FormInput.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Label } from "../Label";
+import type { InputProps } from "../Input";
 import { Input } from "../Input";
 import { HelpText } from "../HelpText";
-import type { InputProps } from "../Input";
 import { Box } from "../../primitives/Box";
 
 export interface FormInputProps
@@ -51,12 +51,10 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
           value={value}
           {...props}
         />
-        {helpText ? (
+        {helpText && (
           <HelpText hasError={hasError} id={`${id}-help-text`}>
             {helpText}
           </HelpText>
-        ) : (
-          <Box.div h="1rem" marginTop="space20" />
         )}
       </Box.div>
     );

--- a/packages/components/src/components/FormSelect/FormSelect.stories.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.stories.tsx
@@ -158,7 +158,12 @@ export const AsControlledFormSelect = (): JSX.Element => {
 
   const selectID = useUID();
   return (
-    <Box.form onSubmit={handleSubmit(onSubmit)}>
+    <Box.form
+      display="flex"
+      flexDirection="column"
+      gap="space20"
+      onSubmit={handleSubmit(onSubmit)}
+    >
       <ControlledFormSelect
         control={control}
         helpText={"Please select a flavor."}

--- a/packages/components/src/components/FormSelect/FormSelect.stories.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useUID } from "react-uid";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import type { SelectProps } from "../Select";
 import { Box } from "../../primitives/Box";
 import { Button } from "../Button";
@@ -158,40 +158,37 @@ export const AsControlledFormSelect = (): JSX.Element => {
 
   const selectID = useUID();
   return (
-    <Box.form
-      display="flex"
-      flexDirection="column"
-      gap="space20"
-      onSubmit={handleSubmit(onSubmit)}
-    >
-      <ControlledFormSelect
-        control={control}
-        helpText={"Please select a flavor."}
-        id={`${selectID}-1`}
-        items={selectItems}
-        label="Select a flavor"
-        name="flavor"
-        placeholder="Maybe something crazy?"
-        required
-      />
-      <ControlledFormSelect
-        control={control}
-        id={`${selectID}-2`}
-        items={selectItems}
-        label="Select a flavor"
-        name="flavor1"
-      />
-      <ControlledFormSelect
-        control={control}
-        id={`${selectID}-3`}
-        items={selectItems}
-        label="Select multiple flavors"
-        name="flavor2"
-      />
-      <Box.div>
-        <Button type="submit" variant="primary">
-          Submit
-        </Button>
+    <Box.form onSubmit={handleSubmit(onSubmit)}>
+      <Box.div display="flex" flexDirection="column" gap="space50">
+        <ControlledFormSelect
+          control={control}
+          helpText={"Please select a flavor."}
+          id={`${selectID}-1`}
+          items={selectItems}
+          label="Select a flavor"
+          name="flavor"
+          placeholder="Maybe something crazy?"
+          required
+        />
+        <ControlledFormSelect
+          control={control}
+          id={`${selectID}-2`}
+          items={selectItems}
+          label="Select a flavor"
+          name="flavor1"
+        />
+        <ControlledFormSelect
+          control={control}
+          id={`${selectID}-3`}
+          items={selectItems}
+          label="Select multiple flavors"
+          name="flavor2"
+        />
+        <Box.div>
+          <Button type="submit" variant="primary">
+            Submit
+          </Button>
+        </Box.div>
       </Box.div>
     </Box.form>
   );

--- a/packages/components/src/components/FormSelect/FormSelect.tsx
+++ b/packages/components/src/components/FormSelect/FormSelect.tsx
@@ -36,12 +36,10 @@ const FormSelect = React.forwardRef<HTMLButtonElement, FormSelectProps>(
           required={required}
           {...props}
         />
-        {helpText ? (
+        {helpText && (
           <HelpText hasError={hasError} id={`${id}-help-text`}>
             {helpText}
           </HelpText>
-        ) : (
-          <Box.div h="1rem" marginTop="space20" />
         )}
       </Box.div>
     );

--- a/packages/components/src/components/FormTextArea/FormTextArea.stories.tsx
+++ b/packages/components/src/components/FormTextArea/FormTextArea.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React, { useEffect } from "react";
 import { useUID } from "react-uid";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { Box } from "../../primitives/Box";
@@ -125,49 +125,51 @@ export const AsControlledFormTextArea = (): JSX.Element => {
   const inputID = useUID();
   return (
     <Box.form onSubmit={handleSubmit(onSubmit)}>
-      <ControlledFormTextArea
-        control={control}
-        data-testid="test"
-        helpText={"Please enter a flavor."}
-        id={`${inputID}-1`}
-        label="Enter a flavor"
-        name="flavor"
-        placeholder="Maybe something crazy?"
-        required
-      />
-      <ControlledFormTextArea
-        control={control}
-        helpText={"Please enter a flavor."}
-        id={`${inputID}-1`}
-        label="Enter a flavor"
-        name="flavor1"
-        placeholder="Maybe something crazy?"
-        required
-      />
-      <ControlledFormTextArea
-        control={control}
-        id={`${inputID}-2`}
-        label="Prefilled flavor"
-        name="flavor2"
-      />
-      <ControlledFormTextArea
-        control={control}
-        disabled
-        id={`${inputID}-2`}
-        label="Disabled flavor"
-        name="flavor3"
-      />
-      <ControlledFormTextArea
-        control={control}
-        id={`${inputID}-2`}
-        label="Read-Only flavor"
-        name="flavor4"
-        readOnly
-      />
-      <Box.div>
-        <Button type="submit" variant="primary">
-          Submit
-        </Button>
+      <Box.div display="flex" flexDirection="column" gap="space50">
+        <ControlledFormTextArea
+          control={control}
+          data-testid="test"
+          helpText={"Please enter a flavor."}
+          id={`${inputID}-1`}
+          label="Enter a flavor"
+          name="flavor"
+          placeholder="Maybe something crazy?"
+          required
+        />
+        <ControlledFormTextArea
+          control={control}
+          helpText={"Please enter a flavor."}
+          id={`${inputID}-1`}
+          label="Enter a flavor"
+          name="flavor1"
+          placeholder="Maybe something crazy?"
+          required
+        />
+        <ControlledFormTextArea
+          control={control}
+          id={`${inputID}-2`}
+          label="Prefilled flavor"
+          name="flavor2"
+        />
+        <ControlledFormTextArea
+          control={control}
+          disabled
+          id={`${inputID}-2`}
+          label="Disabled flavor"
+          name="flavor3"
+        />
+        <ControlledFormTextArea
+          control={control}
+          id={`${inputID}-2`}
+          label="Read-Only flavor"
+          name="flavor4"
+          readOnly
+        />
+        <Box.div>
+          <Button type="submit" variant="primary">
+            Submit
+          </Button>
+        </Box.div>
       </Box.div>
     </Box.form>
   );

--- a/packages/components/src/components/FormTextArea/FormTextArea.tsx
+++ b/packages/components/src/components/FormTextArea/FormTextArea.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Label } from "../Label";
+import type { TextAreaProps } from "../Textarea";
 import { TextArea } from "../Textarea";
 import { HelpText } from "../HelpText";
-import type { TextAreaProps } from "../Textarea";
 import { Box } from "../../primitives/Box";
 
 export interface FormTextAreaProps
@@ -36,12 +36,10 @@ const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
           required={required}
           {...props}
         />
-        {helpText ? (
+        {helpText && (
           <HelpText hasError={hasError} id={`${id}-help-text`}>
             {helpText}
           </HelpText>
-        ) : (
-          <Box.div h="1rem" marginTop="space20" />
         )}
       </Box.div>
     );


### PR DESCRIPTION
## Description of the change

While working with the ControlledFormSelect, I noticed that the FormSelect component has an extra div when there is no helpText message. This div has a marginTop that makes it difficult to align the component within a form with a different gap, for example. 

[It's recommended to avoid](https://css-tricks.com/component-spacing-design-system/) adding spaces in the components themselves because it makes it harder to reuse and encapsulate components. 

For this specific case, I would suggest we create a FormField component that has Label, children and HelpText/ErrorMessage, and then, aligned with Design Team, we set the spaces between them. We can also have a FormLayout, so we align a space and have it more consistently, without adding extra spaces, making it easy when we have design variations and responsive layouts.

The issue: 

![image (67)](https://github.com/Localitos/pluto/assets/5320963/4bbbba12-94ef-4843-b03e-c28dfe346c0e)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
