### PR TITLE
chore: add jest-fail-on-console to avoid silent logs that could be errors

### DIFF
--- a/.jest/jest-setup.ts
+++ b/.jest/jest-setup.ts
@@ -1,8 +1,11 @@
 import "@testing-library/jest-dom";
+import failOnConsole from "jest-fail-on-console";
 
 type JestToErrorArg = Parameters<
   jest.Matchers<unknown, () => unknown>["toThrow"]
 >[0];
+
+failOnConsole({});
 
 const matchers = {
   /**

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "husky": "^8.0.3",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fail-on-console": "^3.1.1",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^15.0.2",
     "next": "^13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11286,6 +11286,13 @@ jest-environment-node@^28.1.3:
     jest-mock "^28.1.3"
     jest-util "^28.1.3"
 
+jest-fail-on-console@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz#4ca0d0cc8f11675e8e9f52159a37a6602a7e6c09"
+  integrity sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==
+  dependencies:
+    chalk "^4.1.0"
+
 jest-get-type@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"


### PR DESCRIPTION
## Description of the change
We might want to avoid silent errors on console

## Testing the change
Make any test emit an warning like removing a waitFor from `packages/components/src/components/Avatar/useGetImageOrientation.test.ts`

## Type of change

- [x] Non-Breaking Change (change to existing functionality)

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
