### PR TITLE
chore: bump several dependencies fixing security alerts and packages version

### DIFF
--- a/.changeset/plenty-turtles-poke.md
+++ b/.changeset/plenty-turtles-poke.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/components": minor
+"@localyze-pluto/theme": minor
+---
+
+Bump several dependencies fixing security alerts and minor changes


### PR DESCRIPTION
## Description of the change
- After merging these packages we are bumping Pluto's version

word-wrap from 1.2.3 to 1.2.5 (#942)
eslint-plugin-cypress from 2.12.1 to 2.15.1 (#1017)
react-hook-form from 7.43.2 to 7.47.0 (#1022)
html-react-parser from 3.0.9 to 3.0.16 (#789)
react-router-dom from 6.8.2 to 6.17.0 (#1035)
@adobe/css-tools from 4.0.1 to 4.3.1 (#981)
lint-staged from 13.1.2 to 15.0.2 (#1050)
@uppy/core from 3.0.6 to 3.6.0 (#1054)
@storybook/addon-docs from 7.0.0-rc.4 to 7.5.1 (#1052)
jest-environment-jsdom from 29.4.0 to 29.7.0 (#1000)
@storybook/addon-viewport from 7.0.22 to 7.5.1 (#1051)
tough-cookie from 4.1.2 to 4.1.3 (#919)
turbo from 1.10.3 to 1.10.16 (#1049)
@heroicons/react from 2.0.16 to 2.0.18 (#904)
semver from 5.7.1 to 5.7.2 (#923)

## Type of change

- [x] Non-Breaking Change (change to existing functionality)

### Development

- [x] All tests related to the changed code pass in development
