### PR TITLE
feat(components): add disabled props to Menu MenuItems

### DIFF
--- a/.changeset/healthy-lobsters-tie.md
+++ b/.changeset/healthy-lobsters-tie.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+add disabled prop to menuItems

--- a/packages/components/src/components/Menu/Menu.stories.tsx
+++ b/packages/components/src/components/Menu/Menu.stories.tsx
@@ -123,3 +123,36 @@ const ManyItemsMenu = (): JSX.Element => {
 export const WithManyItems: Story = {
   render: (): JSX.Element => <ManyItemsMenu />,
 };
+
+const DisabledButtonsMenu = (): JSX.Element => {
+  const items: MenuItemProps[] = [
+    {
+      onClick: noop,
+      label: "Option 1",
+    },
+    {
+      onClick: noop,
+      label: "Option 2",
+      disabled: true,
+    },
+    {
+      onClick: noop,
+      label: "Option 3",
+    },
+    {
+      onClick: noop,
+      label: "Option 4",
+      disabled: true,
+    },
+  ];
+
+  return (
+    <Box.div minHeight="400px">
+      <Menu items={items} />
+    </Box.div>
+  );
+};
+
+export const WithDisabledButtons: Story = {
+  render: (): JSX.Element => <DisabledButtonsMenu />,
+};

--- a/packages/components/src/components/Menu/Menu.test.tsx
+++ b/packages/components/src/components/Menu/Menu.test.tsx
@@ -36,4 +36,21 @@ describe("<Menu />", () => {
     expect(screen.getByText("Item 1")).toBeInTheDocument();
     expect(screen.getByText("Item 2")).toBeInTheDocument();
   });
+
+  it("allows a disabled prop for a menu item and disables the button", () => {
+    render(
+      <Menu items={[{ onClick: jest.fn(), label: "Item 1", disabled: true }]} />
+    );
+
+    const menuButton = screen.getByRole("button");
+    expect(menuButton).toBeInTheDocument();
+
+    userEvent.click(menuButton);
+
+    expect(screen.getByRole("presentation")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: /item 1/i, hidden: true })
+    ).toBeDisabled();
+  });
 });

--- a/packages/components/src/components/Menu/Menu.test.tsx
+++ b/packages/components/src/components/Menu/Menu.test.tsx
@@ -38,9 +38,8 @@ describe("<Menu />", () => {
   });
 
   it("allows a disabled prop for a menu item and disables the button", async () => {
-    render(
-      <Menu items={[{ onClick: jest.fn(), label: "Item 1", disabled: true }]} />
-    );
+    const onClick = jest.fn();
+    render(<Menu items={[{ onClick, label: "Item 1", disabled: true }]} />);
 
     const menuButton = screen.getByRole("button");
     expect(menuButton).toBeInTheDocument();
@@ -50,5 +49,22 @@ describe("<Menu />", () => {
     expect(screen.getByRole("presentation")).toBeInTheDocument();
 
     expect(screen.getByRole("button", { name: /item 1/i })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: /item 1/i }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("calls onClick", async () => {
+    const onClick = jest.fn();
+    render(<Menu items={[{ onClick, label: "Item 1" }]} />);
+
+    const menuButton = screen.getByRole("button");
+    expect(menuButton).toBeInTheDocument();
+
+    await userEvent.click(menuButton);
+
+    expect(screen.getByRole("presentation")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /item 1/i }));
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/packages/components/src/components/Menu/Menu.test.tsx
+++ b/packages/components/src/components/Menu/Menu.test.tsx
@@ -9,13 +9,13 @@ describe("<Menu />", () => {
     { onClick: jest.fn, label: "Item 2" },
   ];
 
-  it("renders correctly", () => {
+  it("renders correctly", async () => {
     render(<Menu items={items} />);
 
     const menuButton = screen.getByRole("button");
     expect(menuButton).toBeInTheDocument();
 
-    userEvent.click(menuButton);
+    await userEvent.click(menuButton);
 
     expect(screen.getByRole("presentation")).toBeInTheDocument();
 
@@ -23,13 +23,13 @@ describe("<Menu />", () => {
     expect(screen.getByText("Item 2")).toBeInTheDocument();
   });
 
-  it("accepts a custom menu button", () => {
+  it("accepts a custom menu button", async () => {
     render(<Menu items={items} menuButton={<button>Custom button</button>} />);
 
     const menuButton = screen.getByText("Custom button");
     expect(menuButton).toBeInTheDocument();
 
-    userEvent.click(menuButton);
+    await userEvent.click(menuButton);
 
     expect(screen.getByRole("presentation")).toBeInTheDocument();
 
@@ -37,7 +37,7 @@ describe("<Menu />", () => {
     expect(screen.getByText("Item 2")).toBeInTheDocument();
   });
 
-  it("allows a disabled prop for a menu item and disables the button", () => {
+  it("allows a disabled prop for a menu item and disables the button", async () => {
     render(
       <Menu items={[{ onClick: jest.fn(), label: "Item 1", disabled: true }]} />
     );
@@ -45,12 +45,10 @@ describe("<Menu />", () => {
     const menuButton = screen.getByRole("button");
     expect(menuButton).toBeInTheDocument();
 
-    userEvent.click(menuButton);
+    await userEvent.click(menuButton);
 
     expect(screen.getByRole("presentation")).toBeInTheDocument();
 
-    expect(
-      screen.getByRole("button", { name: /item 1/i, hidden: true })
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /item 1/i })).toBeDisabled();
   });
 });

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -13,6 +13,7 @@ import { Box } from "../../primitives/Box";
 export type MenuItemProps = {
   label: string;
   onClick: () => void;
+  disabled?: boolean;
 };
 
 export type MenuProps = {
@@ -58,7 +59,7 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
             paddingBottom="space20"
             paddingTop="space20"
           >
-            {map(items, ({ label, onClick }, i) => (
+            {map(items, ({ label, onClick, disabled }, i) => (
               <MenuItem key={i}>
                 <Box.div
                   backgroundColor={{
@@ -66,7 +67,7 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
                     hover: "colorBackgroundWeakest",
                   }}
                 >
-                  <Button onClick={onClick} variant="ghost">
+                  <Button disabled={disabled} onClick={onClick} variant="ghost">
                     <Box.span color="colorTextStrongest">{label}</Box.span>
                   </Button>
                 </Box.div>


### PR DESCRIPTION
## Description of the change

We need to be able to disable the buttons in the menu. Therefore I've added the disabled prop to the menu items here.

## Testing the change
Tests were added for this

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
