### PR TITLE
feat: update menu and icon components

### DIFF
--- a/.changeset/flat-zebras-taste.md
+++ b/.changeset/flat-zebras-taste.md
@@ -1,0 +1,9 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Menu]
+
+- Allow menu items to be also ReactNode
+- Change menu item color and background color when disabled
+  [Icon] Add two new LucidIcons

--- a/packages/components/src/components/Icon/LucideIcons.ts
+++ b/packages/components/src/components/Icon/LucideIcons.ts
@@ -12,6 +12,8 @@ import {
   LucideIcon,
   Copy,
   PenSquare,
+  Pin,
+  Trash2,
 } from "lucide-react";
 import { LucideIconName } from "./types/LucideIconName";
 
@@ -24,8 +26,10 @@ export const LucideIcons: Record<LucideIconName, LucideIcon> = {
   save: Save,
   "mail-question": MailQuestion,
   "pie-chart": PieChart,
+  pin: Pin,
   puzzle: Puzzle,
   wallet: Wallet,
   copy: Copy,
   "pen-square": PenSquare,
+  "trash-2": Trash2,
 };

--- a/packages/components/src/components/Icon/types/LucideIconName.ts
+++ b/packages/components/src/components/Icon/types/LucideIconName.ts
@@ -7,7 +7,9 @@ export type LucideIconName =
   | "palette"
   | "pen-square"
   | "pie-chart"
+  | "pin"
   | "puzzle"
   | "save"
   | "slack"
+  | "trash-2"
   | "wallet";

--- a/packages/components/src/components/Menu/Menu.stories.tsx
+++ b/packages/components/src/components/Menu/Menu.stories.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import noop from "lodash/noop";
 import { Button } from "../Button";
 import { Box } from "../../primitives/Box";
+import { Icon } from "../Icon";
 import { Menu, MenuItemProps } from "./Menu";
 
 const meta: Meta<typeof Menu> = {
@@ -155,4 +156,36 @@ const DisabledButtonsMenu = (): JSX.Element => {
 
 export const WithDisabledButtons: Story = {
   render: (): JSX.Element => <DisabledButtonsMenu />,
+};
+
+export const WithIcons: Story = {
+  render: (): JSX.Element => {
+    const items: MenuItemProps[] = [
+      {
+        onClick: noop,
+        label: (
+          <Box.div alignItems="center" display="flex" gap="space30">
+            <Icon decorative icon="pin" size="sizeIcon20" />
+            <Box.span>Pin to top</Box.span>
+          </Box.div>
+        ),
+      },
+      {
+        onClick: noop,
+        label: (
+          <Box.div alignItems="center" display="flex" gap="space30">
+            <Icon decorative icon="trash-2" size="sizeIcon20" />
+            <Box.span>Delete</Box.span>
+          </Box.div>
+        ),
+        disabled: true,
+      },
+    ];
+
+    return (
+      <Box.div minHeight="100px">
+        <Menu items={items} />
+      </Box.div>
+    );
+  },
 };

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import {
   DisclosureProps,
   Menu as AriakitMenu,
@@ -11,7 +11,7 @@ import { Button } from "../Button";
 import { Box } from "../../primitives/Box";
 
 export type MenuItemProps = {
-  label: string;
+  label: ReactNode | string;
   onClick: () => void;
   disabled?: boolean;
 };
@@ -64,11 +64,17 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
                 <Box.div
                   backgroundColor={{
                     _: "colorBackground",
-                    hover: "colorBackgroundWeakest",
+                    hover: disabled
+                      ? "colorBackground"
+                      : "colorBackgroundWeakest",
                   }}
                 >
                   <Button disabled={disabled} onClick={onClick} variant="ghost">
-                    <Box.span color="colorTextStrongest">{label}</Box.span>
+                    <Box.span
+                      color={disabled ? "colorText" : "colorTextStrongest"}
+                    >
+                      {label}
+                    </Box.span>
                   </Button>
                 </Box.div>
               </MenuItem>


### PR DESCRIPTION
## Description of the change

Updates two components: 

### Menu: 

- Allow menu items to be also ReactNode
- Change menu item color and background color when disabled

### Icon:
 - Add trash-2 and pin icons

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
