### PR TITLE
chore: allow any space token value as marginBottom to Heading component

### DIFF
--- a/.changeset/afraid-cats-marry.md
+++ b/.changeset/afraid-cats-marry.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Allow any space tokens to be used as margin bottom on heading component

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -6,7 +6,7 @@ import forEach from "lodash/forEach";
 import { Text } from "../../primitives/Text";
 
 type HeadingLevelOptions = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-type HeadingMarginOptions = "space0" | "space70";
+type HeadingMarginOptions = keyof Theme["space"];
 type HeadingSizeOptions =
   | "heading10"
   | "heading20"


### PR DESCRIPTION
## Description of the change
- Allow more space tokens to be marginBottom on the Heading component

## Type of change
- [x] Non-Breaking Change (change to existing functionality)

### Development

- [x] All tests related to the changed code pass in development
