### PR TITLE
chore: update github actions/checkout

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.3
         uses: actions/setup-node@v2
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.3
         uses: actions/setup-node@v2
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.3
         uses: actions/setup-node@v2
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.3
         uses: actions/setup-node@v2

--- a/.github/workflows/on_pull_request_package_size.yml
+++ b/.github/workflows/on_pull_request_package_size.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.3
         uses: actions/setup-node@v2

--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v2

--- a/.github/workflows/visual_regression_tests.yml
+++ b/.github/workflows/visual_regression_tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - run: echo ${{ github.triggering_actor }}
       - name: Checkout Commit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache yarn dependencies
         uses: actions/cache@v3
         id: yarn-cache
@@ -33,7 +33,7 @@ jobs:
     if: contains(github.event.pull_request.draft, false)
     needs: install-cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required to retrieve git history
       - name: Restore yarn dependencies

--- a/.github/workflows/visual_regression_tests_main.yml
+++ b/.github/workflows/visual_regression_tests_main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - run: echo ${{ github.triggering_actor }}
       - name: Checkout Commit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache yarn dependencies
         uses: actions/cache@v3
         id: yarn-cache
@@ -33,7 +33,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'chore(release): version packages')"
     needs: install-cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required to retrieve git history
       - name: Restore yarn dependencies


### PR DESCRIPTION
## Description of the change
Update github actions/checkout to v4, avoiding warnings and making them use a new node version. 

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

![image](https://github.com/Localitos/pluto/assets/1165437/8fd20e8a-00e7-4cdb-a930-ba2e10434729)


## Type of change
- Config changes

