### PR TITLE
chore: add optional callback to Confirmation Modal cancel button

### DIFF
--- a/.changeset/rich-swans-ring.md
+++ b/.changeset/rich-swans-ring.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add a onCancel callback to confirmation modal

--- a/packages/components/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/packages/components/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -2,20 +2,26 @@ import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { useModalState } from "../Modal/index";
-import { ConfirmationModal } from "./ConfirmationModal";
+import { ConfirmationModal, ConfirmationModalProps } from "./ConfirmationModal";
 
 const OPEN_MODAL_TEXT = "Open modal";
 
 const onConfirm = jest.fn();
 
-const ExampleModal = () => {
+const ExampleModal = ({
+  onCancel,
+}: Pick<ConfirmationModalProps, "onCancel">) => {
   const state = useModalState();
 
   return (
     <div>
       <button onClick={state.show}>{OPEN_MODAL_TEXT}</button>
 
-      <ConfirmationModal onConfirm={onConfirm} state={state}>
+      <ConfirmationModal
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        state={state}
+      >
         Do you want to confirm?
       </ConfirmationModal>
     </div>
@@ -66,6 +72,19 @@ describe("<ConfirmationModal />", () => {
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("calls onCancel when it is passed as a prop", async () => {
+    const onCancel = jest.fn();
+    render(<ExampleModal onCancel={onCancel} />);
+
+    await userEvent.click(screen.getByText(OPEN_MODAL_TEXT));
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton).toBeInTheDocument();
+    await userEvent.click(cancelButton);
+
+    expect(onCancel).toHaveBeenCalled();
   });
 
   it("renders a custom button label", async () => {

--- a/packages/components/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -9,6 +9,7 @@ export interface ConfirmationModalProps {
   confirmLabel?: string;
   destructive?: boolean;
   onConfirm: () => void;
+  onCancel?: () => void;
 }
 
 /**
@@ -18,6 +19,7 @@ export interface ConfirmationModalProps {
  * @param props.destructive is this a confirmation for a destructive action?
  * @param props.confirmLabel label for the confirm button
  * @param props.onConfirm function to call when clicking the confirm button
+ * @param props.onCancel function to call when clicking the cancel button
  * @param props.children React children for the modal body
  * @returns React.JSX.Element
  */
@@ -32,6 +34,7 @@ const ConfirmationModal = React.forwardRef<
       destructive = false,
       confirmLabel = "Confirm",
       onConfirm,
+      onCancel,
       children,
     },
     _ref,
@@ -45,7 +48,13 @@ const ConfirmationModal = React.forwardRef<
       <Modal maxWidth="25rem" state={state}>
         <ModalBody>{children}</ModalBody>
         <ModalFooter>
-          <Button onClick={state.hide} variant="secondary">
+          <Button
+            onClick={() => {
+              onCancel?.();
+              state.hide();
+            }}
+            variant="secondary"
+          >
             Cancel
           </Button>
           <Button


### PR DESCRIPTION
## Description of the change
Write out a good description of the change. A screenshot or video will also be helpful.
- Add onCancel optional callback to Confirmation Modal 

## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
