### PR TITLE
fix: Remove border radius token that were not working, add correct type to multiple border radius

### DIFF
--- a/.changeset/rich-pans-drop.md
+++ b/.changeset/rich-pans-drop.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Remove border radius props that does not work, enable to pass strings with multiple values

--- a/packages/components/src/primitives/Box/Box.tsx
+++ b/packages/components/src/primitives/Box/Box.tsx
@@ -22,11 +22,12 @@ export interface BoxProps extends SystemProps {
   borderRightWidth?: SystemProp<keyof Theme["borderWidths"], Theme>;
   borderBottonWidth?: SystemProp<keyof Theme["borderWidths"], Theme>;
   borderLeftWidth?: SystemProp<keyof Theme["borderWidths"], Theme>;
-  borderRadius?: SystemProp<keyof Theme["radii"], Theme>;
-  borderTopRightRadius?: SystemProp<keyof Theme["radii"], Theme>;
-  borderTopLeftRadius?: SystemProp<keyof Theme["radii"], Theme>;
-  borderBottomRightRadius?: SystemProp<keyof Theme["radii"], Theme>;
-  borderBottomLeftRadius?: SystemProp<keyof Theme["radii"], Theme>;
+  borderRadius?:
+    | SystemProp<
+        `${keyof Theme["radii"]} ${keyof Theme["radii"]} ${keyof Theme["radii"]} ${keyof Theme["radii"]}`,
+        Theme
+      >
+    | SystemProp<keyof Theme["radii"], Theme>;
   boxShadow?: SystemProp<keyof Theme["shadows"], Theme> | "none";
   color?: SystemProp<keyof Theme["colors"], Theme> | "currentcolor" | "inherit";
   fontFamily?: SystemProp<keyof Theme["fonts"], Theme> | "inherit";


### PR DESCRIPTION
## Description of the change

- Remove `borderTopRightRadius`, `borderTopLeftRadius`, `borderBottomRightRadius`, `borderBottomLeftRadius` because they were not working as expected

for example:

```javascript
export const Default = (): JSX.Element => (
  <Box.div
    backgroundColor="colorBackgroundInfo"
    borderTopRightRadius="borderRadius20"
    padding="space40"
  >
    I&apos;m some text in a box.
  </Box.div>
);
```

results in

![Screen Shot 2023-12-27 at 18 49 41](https://github.com/Localitos/pluto/assets/2047941/a15ed1c2-1fe9-4c65-a835-1783deee5480)

- This PR changes the type of `borderRadius` prop so it can accept borderRadius with different tokens like

so

```javascript
<Box.div
    backgroundColor="colorBackgroundInfo"
    borderRadius="borderRadius0 borderRadius0 borderRadius0 borderRadius50"
    padding="space40"
  >
    I&apos;m some text in a box.
  </Box.div>
```

![Screen Shot 2023-12-27 at 18 54 17](https://github.com/Localitos/pluto/assets/2047941/6d740ad9-d7c4-4171-a3d1-5688632c793e)


## Testing the change

- Change the props value and see it reflects on the storybook

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
