### PR TITLE
feat: add buttonAsLink prop to content card

### DIFF
--- a/.changeset/curly-suits-cry.md
+++ b/.changeset/curly-suits-cry.md
@@ -1,0 +1,8 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[ContentCard]:
+
+- Add `buttonAsLink` prop to make the button act as a link and open in a new tab
+  when clicked

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -31,6 +31,13 @@ Default.args = {
   linkHref,
 };
 
+export const ButtonAsLink = Template.bind({});
+ButtonAsLink.args = {
+  ...defaultProps,
+  linkHref,
+  buttonAsLink: true,
+};
+
 export const Interactive = Template.bind({});
 Interactive.args = {
   ...defaultProps,

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -25,6 +25,8 @@ type CommonProps = {
   date?: string;
   /** Sets the content button text */
   buttonText?: string;
+  /** Sets the content button as a link and adds target="_blank" and rel="noopener noreferrer" */
+  buttonAsLink?: boolean;
   /** Sets a callback to content button */
   onClickButton?: () => void;
   /** Sets the image position on the card */
@@ -76,6 +78,7 @@ export const ContentCard = ({
   iconUrl,
   imagePosition = "right",
   background = "default",
+  buttonAsLink = false,
   as = "div",
 }: ContentCardProps): JSX.Element => {
   const isImageOnTop = imagePosition === "top";
@@ -103,6 +106,10 @@ export const ContentCard = ({
     },
   };
 
+  const buttonProps = buttonAsLink
+    ? { as: "a", href: linkHref, target: "_blank", rel: "noopener noreferrer" }
+    : {};
+
   return (
     <Box.div
       as={href ? "a" : as}
@@ -110,6 +117,7 @@ export const ContentCard = ({
       border={0}
       borderRadius="borderRadius40"
       boxShadow={{
+        _: href ? "shadowStrong" : "none",
         hover: "shadowStrong",
         focusWithin: "shadowStrong",
       }}
@@ -181,7 +189,12 @@ export const ContentCard = ({
         >
           {buttonText && (
             <Box.div w={isImageOnTop ? "50%" : { _: "100%", md: "50%" }}>
-              <Button fullWidth onClick={onClickButton} variant="secondary">
+              <Button
+                fullWidth
+                onClick={onClickButton}
+                variant="secondary"
+                {...buttonProps}
+              >
                 {buttonText}
               </Button>
             </Box.div>


### PR DESCRIPTION
## Description of the change

It adds a prop "buttonAsLink" to the ContentCard to make the Button, when used, acts like a link that will open in a new tab when clicked. 

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
