### PR TITLE
feat: accepts children prop to add a Button with composition

### DIFF
--- a/.changeset/curly-suits-cry.md
+++ b/.changeset/curly-suits-cry.md
@@ -1,8 +1,0 @@
----
-"@localyze-pluto/components": patch
----
-
-[ContentCard]:
-
-- Add `buttonAsLink` prop to make the button act as a link and open in a new tab
-  when clicked

--- a/.changeset/curly-suits-cry.md
+++ b/.changeset/curly-suits-cry.md
@@ -1,0 +1,8 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[ContentCard]:
+
+- Add `buttonAsLink` prop to make the button act as a link and open in a new tab
+  when clicked

--- a/.changeset/yellow-hotels-admire.md
+++ b/.changeset/yellow-hotels-admire.md
@@ -1,0 +1,9 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[ContentCard]:
+
+- Accepts `children` so that it is possible to add a button flexibly
+- Fixes a bug with the shadow state that should be shown in hover only when
+  the card is clickable

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import React from "react";
 import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
 import { ContentCard } from "./ContentCard";
 
 export default {
@@ -19,7 +20,6 @@ const defaultProps = {
   text: "Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et, sodales vel purus.",
   date: "Mon, Sept 5 2022",
   tag: "🏠 Permanent Housing",
-  buttonText: "Go to Page",
   imageSrc: "/images/beach-seal-rocks.jpg",
   imageAlt: "a beach",
 };
@@ -31,11 +31,21 @@ Default.args = {
   linkHref,
 };
 
-export const ButtonAsLink = Template.bind({});
-ButtonAsLink.args = {
+export const WithButton = Template.bind({});
+WithButton.args = {
   ...defaultProps,
-  linkHref,
-  buttonAsLink: true,
+  children: (
+    <Button
+      as="a"
+      fullWidth
+      href={linkHref}
+      rel="noopener noreferrer"
+      target="_blank"
+      variant="secondary"
+    >
+      Go to Page
+    </Button>
+  ),
 };
 
 export const Interactive = Template.bind({});

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -31,6 +31,13 @@ Default.args = {
   linkHref,
 };
 
+export const ButtonAsLink = Template.bind({});
+ButtonAsLink.args = {
+  ...defaultProps,
+  linkHref,
+  buttonAsLink: true,
+};
+
 export const Interactive = Template.bind({});
 Interactive.args = {
   ...defaultProps,

--- a/packages/components/src/components/ContentCard/ContentCard.test.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.test.tsx
@@ -1,11 +1,8 @@
-import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ContentCard } from "./ContentCard";
 
 describe("<ContentCard>", () => {
-  const user = userEvent.setup();
-
   it("renders text props", () => {
     render(
       <ContentCard
@@ -44,36 +41,10 @@ describe("<ContentCard>", () => {
     );
   });
 
-  it("calls onClickButton when the button is clicked", async () => {
-    const onClick = jest.fn();
-
-    render(
-      <ContentCard
-        buttonText="click me"
-        date=""
-        imageAlt=""
-        imageSrc=""
-        onClickButton={onClick}
-        tag=""
-        text=""
-        title=""
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: "click me" });
-
-    expect(button).toBeVisible();
-
-    await user.click(button);
-
-    expect(onClick).toHaveBeenCalled();
-  });
-
   describe("when there is a href", () => {
     it("the card is rendered as a link", () => {
       render(
         <ContentCard
-          buttonText="alow"
           date=""
           href="google.com"
           imageAlt=""
@@ -107,5 +78,15 @@ describe("<ContentCard>", () => {
 
       expect(link).toHaveAttribute("href", "google.com");
     });
+  });
+
+  it("accepts children property", () => {
+    render(
+      <ContentCard date="" href="" imageAlt="" imageSrc="" text="" title="">
+        <button>Click me</button>
+      </ContentCard>,
+    );
+
+    expect(screen.getByRole("button", { name: "Click me" })).toBeVisible();
   });
 });

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -3,7 +3,6 @@ import { Box, BoxProps } from "../../primitives/Box";
 import { Heading } from "../Heading";
 import { Text } from "../../primitives/Text";
 import { Icon } from "../Icon";
-import { Button } from "../Button";
 import { Anchor } from "../Anchor";
 
 type ImagePosition = "right" | "top";
@@ -23,18 +22,14 @@ type CommonProps = {
   tag?: string;
   /** Sets the date to be rendered together with calendar icon */
   date?: string;
-  /** Sets the content button text */
-  buttonText?: string;
-  /** Sets the content button as a link and adds target="_blank" and rel="noopener noreferrer" */
-  buttonAsLink?: boolean;
-  /** Sets a callback to content button */
-  onClickButton?: () => void;
   /** Sets the image position on the card */
   imagePosition?: ImagePosition;
   /** Sets an icon to be rendered over the image */
   iconUrl?: string;
   /** Sets the background color according with the type */
   background?: Background;
+  /** Accepts a children element to be rendered as the Card's content Button */
+  children?: React.ReactNode;
 };
 
 type InteractiveCard = {
@@ -73,13 +68,11 @@ export const ContentCard = ({
   text,
   tag,
   date,
-  buttonText,
-  onClickButton,
   iconUrl,
   imagePosition = "right",
   background = "default",
-  buttonAsLink = false,
   as = "div",
+  children,
 }: ContentCardProps): JSX.Element => {
   const isImageOnTop = imagePosition === "top";
 
@@ -106,21 +99,20 @@ export const ContentCard = ({
     },
   };
 
-  const buttonProps = buttonAsLink
-    ? { as: "a", href: linkHref, target: "_blank", rel: "noopener noreferrer" }
-    : {};
-
   return (
     <Box.div
       as={href ? "a" : as}
       backgroundColor={backgroundColor[background]}
       border={0}
       borderRadius="borderRadius40"
-      boxShadow={{
-        _: href ? "shadowStrong" : "none",
-        hover: "shadowStrong",
-        focusWithin: "shadowStrong",
-      }}
+      boxShadow={
+        href
+          ? {
+              _: "none",
+              hover: "shadowStrong",
+            }
+          : "none"
+      }
       cursor={href ? "pointer" : "default"}
       display="flex"
       flexDirection={
@@ -187,16 +179,9 @@ export const ContentCard = ({
           flexShrink={2}
           gap="space50"
         >
-          {buttonText && (
+          {children && (
             <Box.div w={isImageOnTop ? "50%" : { _: "100%", md: "50%" }}>
-              <Button
-                fullWidth
-                onClick={onClickButton}
-                variant="secondary"
-                {...buttonProps}
-              >
-                {buttonText}
-              </Button>
+              {children}
             </Box.div>
           )}
 

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -25,6 +25,8 @@ type CommonProps = {
   date?: string;
   /** Sets the content button text */
   buttonText?: string;
+  /** Sets the content button as a link and adds target="_blank" and rel="noopener noreferrer" */
+  buttonAsLink?: boolean;
   /** Sets a callback to content button */
   onClickButton?: () => void;
   /** Sets the image position on the card */
@@ -76,6 +78,7 @@ export const ContentCard = ({
   iconUrl,
   imagePosition = "right",
   background = "default",
+  buttonAsLink = false,
   as = "div",
 }: ContentCardProps): JSX.Element => {
   const isImageOnTop = imagePosition === "top";
@@ -103,6 +106,10 @@ export const ContentCard = ({
     },
   };
 
+  const buttonProps = buttonAsLink
+    ? { as: "a", href: linkHref, target: "_blank", rel: "noopener noreferrer" }
+    : {};
+
   return (
     <Box.div
       as={href ? "a" : as}
@@ -110,6 +117,7 @@ export const ContentCard = ({
       border={0}
       borderRadius="borderRadius40"
       boxShadow={{
+        _: href ? "shadowStrong" : "none",
         hover: "shadowStrong",
         focusWithin: "shadowStrong",
       }}
@@ -181,7 +189,12 @@ export const ContentCard = ({
         >
           {buttonText && (
             <Box.div w={isImageOnTop ? "50%" : { _: "100%", md: "50%" }}>
-              <Button fullWidth onClick={onClickButton} variant="secondary">
+              <Button
+                fullWidth
+                onClick={onClickButton}
+                variant="secondary"
+                {...buttonProps}
+              >
                 {buttonText}
               </Button>
             </Box.div>


### PR DESCRIPTION
## Description of the change

[ContentCard]:

- Accepts `children` so that it is possible to add a button flexibly
- Fixes a bug with the shadow state that should be shown in hover only when
  the card is clickable
  
 

https://github.com/Localitos/pluto/assets/5320963/fd1132a7-4220-4034-a08c-ecdd4371838e



## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
