### PR TITLE
fix: add type 'button' to cancel upload button

### DIFF
--- a/.changeset/heavy-ducks-hang.md
+++ b/.changeset/heavy-ducks-hang.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Add type button to CancelUploadButton to avoid triggering a submit when it's part of a form

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -138,7 +138,9 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
           {shouldShowRemoveButton && (
             <RemoveButton disabled={disabled} onClick={onRemove} />
           )}
-          {status === "loading" && <CancelUploadButton onClick={onCancel} />}
+          {status === "loading" && (
+            <CancelUploadButton onClick={onCancel} type="button" />
+          )}
         </Box.div>
         {errorMessage && (
           <HelpText hasError role="alert">


### PR DESCRIPTION
## Description of the change
- Add type `button` to CancelUploadButton to avoid triggering a submit when it's part of a form

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
