### PR TITLE
fix: [ContentCard] remove spaces when image does not fit container

### DIFF
--- a/.changeset/dull-moose-fly.md
+++ b/.changeset/dull-moose-fly.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[ContentCard]: Remove extra spaces when image does not fit the container

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -235,10 +235,10 @@ export const ContentCard = ({
 
         <Box.img
           alt={imageAlt}
-          maxH={{ _: "unset", md: "max-content" }}
-          maxWidth="100%"
+          h="100%"
+          objectFit="cover"
           src={imageSrc}
-          w={{ _: "100%", md: "unset" }}
+          w="100%"
         />
       </Box.div>
     </Box.div>


### PR DESCRIPTION
## Description of the change

This PR fixes the ContentCard component by removing the extra spaces when the image on the right does not fit the container. 

Before: 

![image (85)](https://github.com/Localitos/pluto/assets/5320963/e9fda61a-0b01-4431-b6ed-9a8dc707acd2)

After:

![image (86)](https://github.com/Localitos/pluto/assets/5320963/564b9627-d430-42b1-9996-68d190fb0240)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
