### PR TITLE
fix: update overflow in table

### DIFF
--- a/.changeset/eighty-buses-speak.md
+++ b/.changeset/eighty-buses-speak.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Table]: Add overflow only when needed

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -46,7 +46,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
           borderStyle="borderStyleSolid"
           borderWidth="borderWidth10"
           h="100%"
-          overflow="scroll"
+          overflow="auto"
         >
           <StyledTable
             borderCollapse="separate"


### PR DESCRIPTION
## Description of the change

After updating the Table component, we noticed that we were showing a scrollbar even if the table didn't need to scroll. This PR updates the `overflow` prop to `auto`. 

![image](https://github.com/Localitos/pluto/assets/5320963/de9c449b-7b12-488b-a5f5-ad860e4256bd)


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
