### PR TITLE
fix: table row hover when it is not clickable

### DIFF
--- a/.changeset/poor-penguins-vanish.md
+++ b/.changeset/poor-penguins-vanish.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Table]: Fix hover when table row is not clickable

--- a/packages/components/src/components/Table/Tr.tsx
+++ b/packages/components/src/components/Table/Tr.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import PropTypes from "prop-types";
+import { SystemProp, Theme } from "@localyze-pluto/theme";
 import { Box } from "../../primitives/Box";
 import { TableContext } from "./TableContext";
 
@@ -13,17 +14,32 @@ export interface TrProps
   isClickable?: boolean;
 }
 
+const getTableRowBackgroundColor = (
+  striped: boolean,
+  isClickable: boolean | undefined,
+): SystemProp<keyof Theme["colors"], Theme> => {
+  if (isClickable) {
+    return {
+      hover: "bgBodyMain",
+    };
+  }
+
+  if (striped) {
+    return {
+      even: "bgSecondary",
+    };
+  }
+
+  return "transparent";
+};
+
 /** A row in the table */
 const Tr = React.forwardRef<HTMLTableRowElement, TrProps>(
   ({ children, isClickable, verticalAlign = "middle", ...props }, ref) => {
     const { striped } = useContext(TableContext);
     return (
       <Box.tr
-        backgroundColor={{
-          _: "transparent",
-          even: striped ? "colorBackgroundWeakest" : "transparent",
-          hover: isClickable ? "colorBackgroundWeak" : "transparent",
-        }}
+        backgroundColor={getTableRowBackgroundColor(striped, isClickable)}
         cursor={isClickable ? "pointer" : "default"}
         ref={ref}
         verticalAlign={verticalAlign}


### PR DESCRIPTION
## Description of the change

Unset the `hover` attribute when the table row is not clickable. 

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
