### PR TITLE
Add `flexed` option to `Tabs` component

### DIFF
--- a/.changeset/rare-candles-mix.md
+++ b/.changeset/rare-candles-mix.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add `flexed` option to Tabs component

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -316,7 +316,7 @@ export const Flexed = (): React.JSX.Element => {
           </Tab>
         </TabList>
         <Box.div display="flex" flexDirection="column" flexGrow="1">
-          {selectedTab === "tab1" ? <Tab1/> : <Tab2/>}
+          {selectedTab === "tab1" ? <Tab1 /> : <Tab2 />}
         </Box.div>
       </Tabs>
     </Box.div>

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -277,38 +277,46 @@ WithDivider.parameters = {
   },
 };
 
-const Foo = () => (
+const Tab1 = () => (
   <Box.div
-    borderColor="colorBackgroundComplete"
+    borderColor="colorBorderWeaker"
     borderStyle="borderStyleSolid"
     borderWidth="borderWidth10"
     h="100%"
+    padding="space60"
     w="100%"
   >
-    <h3>Foo</h3>
-    Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et, sodales vel
-    purus.
+    Tab1
   </Box.div>
 );
 
-const Bar = () => <div>Bar</div>;
+const Tab2 = () => (
+  <Box.div
+    borderColor="colorBorderWeaker"
+    borderStyle="borderStyleSolid"
+    borderWidth="borderWidth10"
+    padding="space60"
+  >
+    Tab2
+  </Box.div>
+);
 
 export const Flexed = (): React.JSX.Element => {
-  const [selectedTab, setSelectedTab] = React.useState("foo");
+  const [selectedTab, setSelectedTab] = React.useState("tab1");
 
   return (
     <Box.div display="flex" h="500px">
       <Tabs flexed>
         <TabList aria-label="Page tabs" withDivider>
-          <Tab id="foo" onClick={() => setSelectedTab("foo")}>
-            Foo
+          <Tab id="tab1" onClick={() => setSelectedTab("tab1")}>
+            Tab1
           </Tab>
-          <Tab id="bar" onClick={() => setSelectedTab("bar")}>
-            Foo
+          <Tab id="tab2" onClick={() => setSelectedTab("tab2")}>
+            Tab2
           </Tab>
         </TabList>
         <Box.div display="flex" flexDirection="column" flexGrow="1">
-          {selectedTab === "foo" ? <Foo /> : <Bar />}
+          {selectedTab === "tab1" ? <Tab1/> : <Tab2/>}
         </Box.div>
       </Tabs>
     </Box.div>

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -277,33 +277,38 @@ WithDivider.parameters = {
   },
 };
 
+const Foo = () => (
+  <Box.div
+    borderColor="colorBackgroundComplete"
+    borderStyle="borderStyleSolid"
+    borderWidth="borderWidth10"
+    h="100%"
+    w="100%"
+  >
+    <h3>Foo</h3>
+    Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et, sodales vel
+    purus.
+  </Box.div>
+);
+
+const Bar = () => <div>Bar</div>;
+
 export const Flexed = (): React.JSX.Element => {
+  const [selectedTab, setSelectedTab] = React.useState("foo");
+
   return (
     <Box.div display="flex" h="500px">
       <Tabs flexed>
         <TabList aria-label="Page tabs" withDivider>
-          <Tab>Tab One</Tab>
-          <Tab>Tab Two</Tab>
+          <Tab id="foo" onClick={() => setSelectedTab("foo")}>
+            Foo
+          </Tab>
+          <Tab id="bar" onClick={() => setSelectedTab("bar")}>
+            Foo
+          </Tab>
         </TabList>
         <Box.div display="flex" flexDirection="column" flexGrow="1">
-          <Box.div>
-            Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
-            sodales vel purus.
-          </Box.div>
-          <Box.div>
-            Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
-            sodales vel purus.
-          </Box.div>
-          <Box.div
-            borderColor="colorBackgroundComplete"
-            borderStyle="borderStyleSolid"
-            borderWidth="borderWidth10"
-            h="100%"
-            w="100%"
-          >
-            Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
-            sodales vel purus.
-          </Box.div>
+          {selectedTab === "foo" ? <Foo /> : <Bar />}
         </Box.div>
       </Tabs>
     </Box.div>

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -21,7 +21,7 @@ const tabs: Meta<typeof Tabs> = {
 
 export default tabs;
 
-export const Default = (): JSX.Element => {
+export const Default = (): React.JSX.Element => {
   return (
     <Tabs>
       <TabList aria-label="Page tabs">
@@ -68,7 +68,7 @@ export const Default = (): JSX.Element => {
   );
 };
 
-export const InitialTab = (): JSX.Element => {
+export const InitialTab = (): React.JSX.Element => {
   const selectedTab = "selected-tab";
   return (
     <Tabs initialTabId={selectedTab}>
@@ -116,7 +116,7 @@ export const InitialTab = (): JSX.Element => {
   );
 };
 
-export const Disabled = (): JSX.Element => {
+export const Disabled = (): React.JSX.Element => {
   return (
     <Tabs>
       <TabList aria-label="Page tabs">
@@ -163,7 +163,7 @@ export const Disabled = (): JSX.Element => {
   );
 };
 
-export const ReallyLongTab = (): JSX.Element => {
+export const ReallyLongTab = (): React.JSX.Element => {
   return (
     <Tabs>
       <TabList aria-label="Page tabs">
@@ -198,7 +198,7 @@ export const ReallyLongTab = (): JSX.Element => {
   );
 };
 
-export const Fitted = (): JSX.Element => {
+export const Fitted = (): React.JSX.Element => {
   return (
     <Tabs variant="fitted">
       <TabList aria-label="Page tabs">
@@ -233,7 +233,7 @@ export const Fitted = (): JSX.Element => {
   );
 };
 
-export const WithDivider = (): JSX.Element => {
+export const WithDivider = (): React.JSX.Element => {
   return (
     <Tabs>
       <TabList aria-label="Page tabs" withDivider>
@@ -273,6 +273,48 @@ WithDivider.parameters = {
     description: {
       story:
         "You can display a divider between the tabs and the content by using the `withDivider` property on the `TabList` component.",
+    },
+  },
+};
+
+export const Flexed = (): React.JSX.Element => {
+  return (
+    <Box.div display="flex" h="500px">
+      <Tabs flexed>
+        <TabList aria-label="Page tabs" withDivider>
+          <Tab>Tab One</Tab>
+          <Tab>Tab Two</Tab>
+        </TabList>
+        <Box.div display="flex" flexDirection="column" flexGrow="1">
+          <Box.div>
+            Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+            sodales vel purus.
+          </Box.div>
+          <Box.div>
+            Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+            sodales vel purus.
+          </Box.div>
+          <Box.div
+            borderColor="colorBackgroundComplete"
+            borderStyle="borderStyleSolid"
+            borderWidth="borderWidth10"
+            h="100%"
+            w="100%"
+          >
+            Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
+            sodales vel purus.
+          </Box.div>
+        </Box.div>
+      </Tabs>
+    </Box.div>
+  );
+};
+
+Flexed.parameters = {
+  docs: {
+    description: {
+      story:
+        "This uses {display: flex; flex-direction: column; flex-grow: 1;} for the div wrapping the tabs, to be able to fill the whole remaining container height with one of the containing divs.",
     },
   },
 };

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -10,13 +10,15 @@ export interface TabsProps {
   initialTabId?: string;
   /** Changes the Tabs' to either fit the width of the containing element or not. */
   variant?: TabsVariants;
+  /** Use flex column, growing to 1 for the div wrapping the tabs. */
+  flexed?: boolean;
   /** The child elements. */
   children: NonNullable<React.ReactNode>;
 }
 
 /** Tabs are labeled controls that allow users to switch between multiple views within a page */
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
-  ({ children, initialTabId, variant }, ref) => {
+  ({ children, initialTabId, variant, flexed }, ref) => {
     const tab = useTabPrimitiveState({
       defaultSelectedId: initialTabId,
     });
@@ -26,7 +28,16 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
       <TabsContext.Provider value={value}>{children}</TabsContext.Provider>
     );
 
-    return <Box.div ref={ref}>{returnValue}</Box.div>;
+    return (
+      <Box.div
+        display={flexed ? "flex" : "block"}
+        flexDirection={flexed ? "column" : undefined}
+        flexGrow={flexed ? "1" : undefined}
+        ref={ref}
+      >
+        {returnValue}
+      </Box.div>
+    );
   },
 );
 


### PR DESCRIPTION
## Description of the change

For the new reporting graphs we will add tabs to the reporting page which breaks the AG Grid results as they use 100% height for the result set, which leads to no results at all being visible since the Tabs wrapper div has display block and therefore does not fill the whole view port height.

![Screenshot_20240306_092242](https://github.com/Localitos/pluto/assets/6059188/d22faad1-27b6-4d86-bba7-da73f2928403)
![Screenshot_20240306_092306](https://github.com/Localitos/pluto/assets/6059188/3b79c118-6fea-4014-b37d-485964b984a9)



## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Before (without `flexed`)
![Screenshot_20240306_095618](https://github.com/Localitos/pluto/assets/6059188/ee4aefa5-6e67-404f-94d4-a30113bf1408)


### After (with `flexed`)
![Screenshot_20240306_095635](https://github.com/Localitos/pluto/assets/6059188/6765cfc1-8945-4ab3-9c06-0a4520ec064b)
