### PR TITLE
feat: add isHoverable prop to table row

### DIFF
--- a/.changeset/brave-oranges-lie.md
+++ b/.changeset/brave-oranges-lie.md
@@ -1,0 +1,9 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Table]:
+
+- Make striped tables working with hoverable rows by introducing a new prop `hasHover`
+- Add back the old background tokens because we need to first introduce the specific tokens
+  like "bgHover" and then update in places like tables.

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -143,7 +143,7 @@ export const StickyHeaders: Story = {
   ),
 };
 
-export const WithClickableRows: Story = {
+export const WithClickableRowsAndHoverable: Story = {
   render: () => (
     <Box.div h="20rem" overflowY="auto">
       <Table>
@@ -156,7 +156,7 @@ export const WithClickableRows: Story = {
         </THead>
         <TBody>
           {map([...Array.from({ length: 100 }).keys()], (index) => (
-            <Tr isClickable key={index}>
+            <Tr hasHover isClickable key={index}>
               <Td>Content</Td>
               <Td>Content</Td>
               <Td>Content</Td>
@@ -167,6 +167,7 @@ export const WithClickableRows: Story = {
     </Box.div>
   ),
 };
+
 export const Striped: Story = {
   render: () => (
     <Table striped>
@@ -346,4 +347,54 @@ ReactTable.parameters = {
     storyDescription:
       "The table elements can be used with a headless table libray like Tanstack Table, formerly React Table. This allows you to build a datagrid on with the Pluto table elements.",
   },
+};
+
+export const Hoverable: Story = {
+  render: () => (
+    <Box.div h="20rem" overflowY="auto">
+      <Table>
+        <THead isSticky>
+          <Tr>
+            <Th>Column 1</Th>
+            <Th>Column 2</Th>
+            <Th>Column 3</Th>
+          </Tr>
+        </THead>
+        <TBody>
+          {map([...Array.from({ length: 100 }).keys()], (index) => (
+            <Tr hasHover key={index}>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+    </Box.div>
+  ),
+};
+
+export const StripedAndHoverable: Story = {
+  render: () => (
+    <Box.div h="20rem" overflowY="auto">
+      <Table striped>
+        <THead isSticky>
+          <Tr>
+            <Th>Column 1</Th>
+            <Th>Column 2</Th>
+            <Th>Column 3</Th>
+          </Tr>
+        </THead>
+        <TBody>
+          {map([...Array.from({ length: 100 }).keys()], (index) => (
+            <Tr hasHover key={index}>
+              <Td>Content</Td>
+              <Td>Content</Td>
+              <Td>Content</Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+    </Box.div>
+  ),
 };

--- a/packages/components/src/components/Table/Tr.tsx
+++ b/packages/components/src/components/Table/Tr.tsx
@@ -12,34 +12,45 @@ export interface TrProps
   verticalAlign?: "bottom" | "middle" | "top";
   /** Determines whether to add a hover background color to the row if it's clickable. */
   isClickable?: boolean;
+  /** Determines whether to add a hover background color to the row when hovered. */
+  hasHover?: boolean;
 }
 
 const getTableRowBackgroundColor = (
   striped: boolean,
-  isClickable: boolean | undefined,
+  hasHover: boolean | undefined,
 ): SystemProp<keyof Theme["colors"], Theme> => {
-  if (isClickable) {
+  if (striped && hasHover) {
     return {
-      hover: "bgBodyMain",
+      even: "colorBackgroundWeakest",
+      hover: "colorBackgroundWeak",
     };
   }
 
-  if (striped) {
+  if (hasHover) {
     return {
-      even: "bgSecondary",
+      hover: "colorBackgroundWeak",
     };
   }
 
-  return "transparent";
+  return striped
+    ? {
+        even: "colorBackgroundWeakest",
+      }
+    : "transparent";
 };
 
 /** A row in the table */
 const Tr = React.forwardRef<HTMLTableRowElement, TrProps>(
-  ({ children, isClickable, verticalAlign = "middle", ...props }, ref) => {
+  (
+    { children, isClickable, hasHover, verticalAlign = "middle", ...props },
+    ref,
+  ) => {
     const { striped } = useContext(TableContext);
+
     return (
       <Box.tr
-        backgroundColor={getTableRowBackgroundColor(striped, isClickable)}
+        backgroundColor={getTableRowBackgroundColor(striped, hasHover)}
         cursor={isClickable ? "pointer" : "default"}
         ref={ref}
         verticalAlign={verticalAlign}


### PR DESCRIPTION
## Description of the change

When we updated the Table component to unset the hover state when a row wasn't clickable, we broke the striped version, when isClickable and striped could not work at the same time. 

This PR adds a new property called `isHoverable` to the table row and makes it possible to be hoverable and striped at the same time. The `isClickable` prop now only changes the `cursor` to `pointer` when true. 

Besides that, I put it back the old background tokens because we need to first introduce the specific tokens like "bgHover" and then update them in places like tables.

All the examples can be seen [here](https://632b1baf1257171b6a84f370-nsoxbxopty.chromatic.com/?path=/docs/components-table--docs)

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
