### PR TITLE
feat: Enable prefixes for multiple tokens on docs

### DIFF
--- a/.changeset/seven-trains-judge.md
+++ b/.changeset/seven-trains-judge.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/design-tokens": minor
+---
+
+Enable multiple prefixes per design token type (example, on colors you can have now color, content, bg, ...)

--- a/packages/design-tokens/docs/borders.mdx
+++ b/packages/design-tokens/docs/borders.mdx
@@ -11,12 +11,12 @@ import { TokensTable } from "./components/TokensTable";
 
 ## Border Styles
 
-<TokensTable type="border-style" data={borderStyleTokens} />
+<TokensTable data={borderStyleTokens} />
 
 ## Border Widths
 
-<TokensTable type="border-width" data={borderWidthTokens} />
+<TokensTable data={borderWidthTokens} />
 
 ## Border Radii
 
-<TokensTable type="border-radius" data={borderRadiiTokens} />
+<TokensTable data={borderRadiiTokens} />

--- a/packages/design-tokens/docs/colors.mdx
+++ b/packages/design-tokens/docs/colors.mdx
@@ -7,4 +7,4 @@ import { TokensTable } from "./components/TokensTable";
 
 <br />
 
-<TokensTable type="color" data={colorTokens} />
+<TokensTable data={colorTokens} />

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../../components/src/components/Table/";
 import { Token } from "../types/Token";
 import { buildTokensTableRows } from "../utils";
+import { TokenRow } from "../types/TokenRow";
 import { TOKEN_COLUMNS } from "./constants";
 import { TokenName } from "./TokenName";
 
@@ -31,7 +32,7 @@ export const TokensTable = ({
     return TOKEN_COLUMNS[token];
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rowGroups = map(columnGroups, (columns: any, index) => {
+  const rowGroups: TokenRow[][] = map(columnGroups, (columns: any, index) => {
     const token = tokenNames[index];
     return buildTokensTableRows(columns, data[token]);
   });

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -16,12 +16,9 @@ import { TokenRow } from "../types/TokenRow";
 import { TOKEN_COLUMNS } from "./constants";
 import { TokenName } from "./TokenName";
 
-type TokenTypes = keyof typeof TOKEN_COLUMNS;
-
 export const TokensTable = ({
   data,
 }: {
-  type: TokenTypes;
   data: Record<string, Record<string, Token>>;
 }): JSX.Element => {
   const tokenNames: Array<string> = filter(
@@ -31,8 +28,7 @@ export const TokensTable = ({
   const columnGroups = map(tokenNames, (token) => {
     return TOKEN_COLUMNS[token];
   });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rowGroups: TokenRow[][] = map(columnGroups, (columns: any, index) => {
+  const rowGroups: TokenRow[][] = map(columnGroups, (columns, index) => {
     const token = tokenNames[index];
     return buildTokensTableRows(columns, data[token]);
   });

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -51,8 +51,6 @@ export const TokensTable = ({
       <TBody>
         {map(rowGroups, (rows) =>
           map(rows, (row) => {
-            console.log(row, row[0]);
-
             const tokenName = row[0] as string;
             return (
               <Tr key={tokenName}>

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -12,6 +12,8 @@ import { Token } from "../types/Token";
 import { buildTokensTableRows } from "../utils";
 import { TOKEN_COLUMNS } from "./constants";
 import { TokenName } from "./TokenName";
+import keys from "lodash/keys";
+import filter from "lodash/filter";
 
 type TokenTypes = keyof typeof TOKEN_COLUMNS;
 
@@ -22,42 +24,54 @@ export const TokensTable = ({
   type: TokenTypes;
   data: Record<string, Record<string, Token>>;
 }): JSX.Element => {
-  const columns = TOKEN_COLUMNS[type];
-  const rows = buildTokensTableRows(columns, data);
+  const tokenNames = filter(keys(data), (item) => item !== "default");
+  const columnGroups = map(tokenNames, (token) => {
+    return TOKEN_COLUMNS[token];
+  });
+  const rowGroups = map(columnGroups, (columns, index) => {
+    const token = tokenNames[index];
+    return buildTokensTableRows(columns, data[token]);
+  });
 
   return (
     <Table style={{ width: "100%" }}>
       <THead>
         <Tr>
-          {map(columns, (column) => {
+          {map(columnGroups[0], (column) => {
             return (
               <Th key={column.name}>
                 <h3>{column.name}</h3>
               </Th>
             );
           })}
+          {/* {map(columnGroups, (columns) =>
+          )} */}
         </Tr>
       </THead>
       <TBody>
-        {map(rows, (row) => {
-          const tokenName = row[0] as string;
-          return (
-            <Tr key={tokenName}>
-              {map(row, (cell, index) => {
-                const column = columns[index].name;
-                return (
-                  <Td key={`${tokenName}${column}`}>
-                    {index === 0 ? (
-                      <TokenName tokenName={cell as string} />
-                    ) : (
-                      cell
-                    )}
-                  </Td>
-                );
-              })}
-            </Tr>
-          );
-        })}
+        {map(rowGroups, (rows) =>
+          map(rows, (row) => {
+            console.log(row, row[0]);
+
+            const tokenName = row[0] as string;
+            return (
+              <Tr key={tokenName}>
+                {map(row, (cell, index) => {
+                  const column = columnGroups[0][index].name;
+                  return (
+                    <Td key={`${tokenName}${column}`}>
+                      {index === 0 ? (
+                        <TokenName tokenName={cell as string} />
+                      ) : (
+                        cell
+                      )}
+                    </Td>
+                  );
+                })}
+              </Tr>
+            );
+          })
+        )}
       </TBody>
     </Table>
   );

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -24,7 +24,7 @@ export const TokensTable = ({
   type: TokenTypes;
   data: Record<string, Record<string, Token>>;
 }): JSX.Element => {
-  const tokenNames = filter(keys(data), (item) => item !== "default");
+  const tokenNames: Array<string> = filter(keys(data), (item) => item !== "default");
   const columnGroups = map(tokenNames, (token) => {
     return TOKEN_COLUMNS[token];
   });
@@ -44,8 +44,6 @@ export const TokensTable = ({
               </Th>
             );
           })}
-          {/* {map(columnGroups, (columns) =>
-          )} */}
         </Tr>
       </THead>
       <TBody>

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import map from "lodash/map";
+import keys from "lodash/keys";
+import filter from "lodash/filter";
 import {
   Table,
   THead,
@@ -12,23 +14,24 @@ import { Token } from "../types/Token";
 import { buildTokensTableRows } from "../utils";
 import { TOKEN_COLUMNS } from "./constants";
 import { TokenName } from "./TokenName";
-import keys from "lodash/keys";
-import filter from "lodash/filter";
 
 type TokenTypes = keyof typeof TOKEN_COLUMNS;
 
 export const TokensTable = ({
-  type,
   data,
 }: {
   type: TokenTypes;
   data: Record<string, Record<string, Token>>;
 }): JSX.Element => {
-  const tokenNames: Array<string> = filter(keys(data), (item) => item !== "default");
+  const tokenNames: Array<string> = filter(
+    keys(data),
+    (item) => item !== "default",
+  );
   const columnGroups = map(tokenNames, (token) => {
     return TOKEN_COLUMNS[token];
   });
-  const rowGroups = map(columnGroups, (columns, index) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rowGroups = map(columnGroups, (columns: any, index) => {
     const token = tokenNames[index];
     return buildTokensTableRows(columns, data[token]);
   });
@@ -66,7 +69,7 @@ export const TokensTable = ({
                 })}
               </Tr>
             );
-          })
+          }),
         )}
       </TBody>
     </Table>

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -9,6 +9,8 @@ import borderWidthTokens from "../../src/tokens/border-width.tokens.json";
 import borderRadiiTokens from "../../src/tokens/border-radius.tokens.json";
 import { Icon } from "../../../components/src/components/Icon/Icon";
 import { TokenEntry } from "../types/TokenEntry";
+import camelCase from "lodash/camelCase";
+import capitalize from "lodash/capitalize";
 import {
   getTokenComment,
   getTokenKey,
@@ -35,17 +37,17 @@ const COLORS = reduce(
       {
         name: "Name",
         transform: ([, token]) => {
-          return cur + token[0];
+          return camelCase(`${cur}${capitalize(token[0])}`);
         },
       },
       { name: "Hex", transform: getTokenValue },
       {
         name: "RGB",
-        transform: ([, token]: TokenEntry): string => hexToRgb(token.value),
+        transform: ([, token]: TokenEntry): string => hexToRgb(token[1].value),
       },
       {
         name: "Hsla",
-        transform: ([, token]: TokenEntry): string => hexToHsla(token.value),
+        transform: ([, token]: TokenEntry): string => hexToHsla(token[1].value),
       },
       {
         name: "Preview",

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -1,4 +1,9 @@
 import React from "react";
+import camelCase from "lodash/camelCase";
+import capitalize from "lodash/capitalize";
+import keys from "lodash/keys";
+import filter from "lodash/filter";
+import reduce from "lodash/reduce";
 import fontSizeTokens from "../../src/tokens/font-size.tokens.json";
 import fontWeightTokens from "../../src/tokens/font-weight.tokens.json";
 import colorTokens from "../../src/tokens/color.tokens.json";
@@ -8,9 +13,7 @@ import borderStyleTokens from "../../src/tokens/border-style.tokens.json";
 import borderWidthTokens from "../../src/tokens/border-width.tokens.json";
 import borderRadiiTokens from "../../src/tokens/border-radius.tokens.json";
 import { Icon } from "../../../components/src/components/Icon/Icon";
-import { TokenEntry } from "../types/TokenEntry";
-import camelCase from "lodash/camelCase";
-import capitalize from "lodash/capitalize";
+import { TokenTuple } from "../types/TokenTuple";
 import {
   getTokenComment,
   getTokenKey,
@@ -22,9 +25,6 @@ import {
 import { Box } from "../../../components/src/primitives/Box";
 import { Text } from "../../../components/src/primitives/Text";
 import { createPreview } from "./createPreview";
-import keys from "lodash/keys";
-import filter from "lodash/filter";
-import reduce from "lodash/reduce";
 
 const TEXT_PREVIEW = (
   <Text.span>The quick brown fox jumped over the lazy dog.</Text.span>
@@ -36,23 +36,23 @@ const COLORS = reduce(
     const arr = [
       {
         name: "Name",
-        transform: ([, token]) => {
+        transform: ([, token]: TokenTuple) => {
           return camelCase(`${cur}${capitalize(token[0])}`);
         },
       },
       { name: "Hex", transform: getTokenValue },
       {
         name: "RGB",
-        transform: ([, token]: TokenEntry): string => hexToRgb(token[1].value),
+        transform: ([, token]: TokenTuple): string => hexToRgb(token[1].value),
       },
       {
         name: "Hsla",
-        transform: ([, token]: TokenEntry): string => hexToHsla(token[1].value),
+        transform: ([, token]: TokenTuple): string => hexToHsla(token[1].value),
       },
       {
         name: "Preview",
         transform: createPreview({
-          prefix: getTokenKey(colorTokens),
+          prefix: cur,
           attribute: "backgroundColor",
           componentProps: {
             w: "70px",
@@ -68,7 +68,7 @@ const COLORS = reduce(
       [cur]: arr,
     };
   },
-  {}
+  {},
 );
 
 export const TOKEN_COLUMNS = {

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -20,9 +20,53 @@ import {
 import { Box } from "../../../components/src/primitives/Box";
 import { Text } from "../../../components/src/primitives/Text";
 import { createPreview } from "./createPreview";
+import keys from "lodash/keys";
+import filter from "lodash/filter";
+import reduce from "lodash/reduce";
 
 const TEXT_PREVIEW = (
   <Text.span>The quick brown fox jumped over the lazy dog.</Text.span>
+);
+
+const COLORS = reduce(
+  filter(keys(colorTokens), (item) => item !== "default"),
+  (acc, cur) => {
+    const arr = [
+      {
+        name: "Name",
+        transform: ([, token]) => {
+          return cur + token[0];
+        },
+      },
+      { name: "Hex", transform: getTokenValue },
+      {
+        name: "RGB",
+        transform: ([, token]: TokenEntry): string => hexToRgb(token.value),
+      },
+      {
+        name: "Hsla",
+        transform: ([, token]: TokenEntry): string => hexToHsla(token.value),
+      },
+      {
+        name: "Preview",
+        transform: createPreview({
+          prefix: getTokenKey(colorTokens),
+          attribute: "backgroundColor",
+          componentProps: {
+            w: "70px",
+            h: "30px",
+            borderRadius: "borderRadius35",
+          },
+        }),
+      },
+    ];
+
+    return {
+      ...acc,
+      [cur]: arr,
+    };
+  },
+  {}
 );
 
 export const TOKEN_COLUMNS = {
@@ -180,31 +224,5 @@ export const TOKEN_COLUMNS = {
       }),
     },
   ],
-  [getTokenKey(colorTokens)]: [
-    {
-      name: "Name",
-      transform: getTokenName(colorTokens),
-    },
-    { name: "Hex", transform: getTokenValue },
-    {
-      name: "RGB",
-      transform: ([, token]: TokenEntry): string => hexToRgb(token.value),
-    },
-    {
-      name: "Hsla",
-      transform: ([, token]: TokenEntry): string => hexToHsla(token.value),
-    },
-    {
-      name: "Preview",
-      transform: createPreview({
-        prefix: getTokenKey(colorTokens),
-        attribute: "backgroundColor",
-        componentProps: {
-          w: "70px",
-          h: "30px",
-          borderRadius: "borderRadius35",
-        },
-      }),
-    },
-  ],
+  ...COLORS,
 };

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -24,11 +24,16 @@ import {
 } from "../utils";
 import { Box } from "../../../components/src/primitives/Box";
 import { Text } from "../../../components/src/primitives/Text";
+import { TokenColumn } from "../types/TokenColumn";
 import { createPreview } from "./createPreview";
 
 const TEXT_PREVIEW = (
   <Text.span>The quick brown fox jumped over the lazy dog.</Text.span>
 );
+
+type TokenColumnsProps = {
+  [key: string]: Array<TokenColumn>;
+};
 
 const COLORS = reduce(
   filter(keys(colorTokens), (item) => item !== "default"),
@@ -71,7 +76,7 @@ const COLORS = reduce(
   {},
 );
 
-export const TOKEN_COLUMNS = {
+export const TOKEN_COLUMNS: TokenColumnsProps = {
   [getTokenKey(borderRadiiTokens)]: [
     {
       name: "Name",

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -41,18 +41,18 @@ const COLORS = reduce(
     const arr = [
       {
         name: "Name",
-        transform: ([, token]: TokenTuple) => {
-          return camelCase(`${cur}${capitalize(token[0])}`);
+        transform: ([tokenName]: TokenTuple) => {
+          return camelCase(`${cur}${capitalize(tokenName)}`);
         },
       },
       { name: "Hex", transform: getTokenValue },
       {
         name: "RGB",
-        transform: ([, token]: TokenTuple): string => hexToRgb(token[1].value),
+        transform: ([, token]: TokenTuple): string => hexToRgb(token.value),
       },
       {
         name: "Hsla",
-        transform: ([, token]: TokenTuple): string => hexToHsla(token[1].value),
+        transform: ([, token]: TokenTuple): string => hexToHsla(token.value),
       },
       {
         name: "Preview",

--- a/packages/design-tokens/docs/components/createPreview.tsx
+++ b/packages/design-tokens/docs/components/createPreview.tsx
@@ -26,10 +26,10 @@ export const createPreview =
     component: Component = Box.div,
   }: PreviewProps) =>
   // eslint-disable-next-line react/display-name
-  ([, token]: TokenTuple): JSX.Element => {
-    const tokenProps = overrideProps[token[0]];
+  ([tokenName, token]: TokenTuple): JSX.Element => {
+    const tokenProps = overrideProps[token.value];
     const normalizedSuffix = replace(
-      upperFirst(camelCase(token[0])),
+      upperFirst(camelCase(tokenName)),
       "Negative",
       "",
     );

--- a/packages/design-tokens/docs/components/createPreview.tsx
+++ b/packages/design-tokens/docs/components/createPreview.tsx
@@ -3,7 +3,7 @@ import replace from "lodash/replace";
 import camelCase from "lodash/camelCase";
 import upperFirst from "lodash/upperFirst";
 import { ThemeProvider, theme } from "@localyze-pluto/theme";
-import { TokenEntry } from "../types/TokenEntry";
+import { TokenTuple } from "../types/TokenTuple";
 import { Box, BoxProps } from "../../../components/src/primitives/Box";
 import { IconProps } from "../../../components/src/components/Icon/Icon";
 
@@ -26,10 +26,10 @@ export const createPreview =
     component: Component = Box.div,
   }: PreviewProps) =>
   // eslint-disable-next-line react/display-name
-  ([suffix]: TokenEntry): JSX.Element => {
-    const tokenProps = overrideProps[suffix];
+  ([, token]: TokenTuple): JSX.Element => {
+    const tokenProps = overrideProps[token[0]];
     const normalizedSuffix = replace(
-      upperFirst(camelCase(suffix)),
+      upperFirst(camelCase(token[0])),
       "Negative",
       "",
     );
@@ -40,8 +40,6 @@ export const createPreview =
       children,
       [attribute]: `${camelCase(prefix)}${normalizedSuffix}`,
     };
-
-    console.log(suffix)
 
     return (
       <ThemeProvider theme={theme}>

--- a/packages/design-tokens/docs/components/createPreview.tsx
+++ b/packages/design-tokens/docs/components/createPreview.tsx
@@ -41,6 +41,8 @@ export const createPreview =
       [attribute]: `${camelCase(prefix)}${normalizedSuffix}`,
     };
 
+    console.log(suffix)
+
     return (
       <ThemeProvider theme={theme}>
         <Box.div className="sb-unstyled">

--- a/packages/design-tokens/docs/font-sizes.mdx
+++ b/packages/design-tokens/docs/font-sizes.mdx
@@ -7,4 +7,4 @@ import * as fontSizeTokens from "../src/tokens/font-size.tokens.json";
 
 <br />
 
-<TokensTable type="font-size" data={fontSizeTokens} />
+<TokensTable data={fontSizeTokens} />

--- a/packages/design-tokens/docs/font-weights.mdx
+++ b/packages/design-tokens/docs/font-weights.mdx
@@ -7,4 +7,4 @@ import * as fontWeightTokens from "../src/tokens/font-weight.tokens.json";
 
 <br />
 
-<TokensTable type="font-weight" data={fontWeightTokens} />
+<TokensTable data={fontWeightTokens} />

--- a/packages/design-tokens/docs/icon-sizes.mdx
+++ b/packages/design-tokens/docs/icon-sizes.mdx
@@ -7,4 +7,4 @@ import * as iconSizeTokens from "../src/tokens/size.tokens.json";
 
 <br />
 
-<TokensTable type="size" data={iconSizeTokens} />
+<TokensTable data={iconSizeTokens} />

--- a/packages/design-tokens/docs/spacing.mdx
+++ b/packages/design-tokens/docs/spacing.mdx
@@ -7,4 +7,4 @@ import * as spaceTokens from "../src/tokens/space.tokens.json";
 
 <br />
 
-<TokensTable type="space" data={spaceTokens} />
+<TokensTable data={spaceTokens} />

--- a/packages/design-tokens/docs/types/TokenTuple.ts
+++ b/packages/design-tokens/docs/types/TokenTuple.ts
@@ -1,0 +1,3 @@
+import { Token } from "./Token";
+
+export type TokenTuple = [undefined, [string, Token]];

--- a/packages/design-tokens/docs/types/TokenTuple.ts
+++ b/packages/design-tokens/docs/types/TokenTuple.ts
@@ -1,3 +1,3 @@
 import { Token } from "./Token";
 
-export type TokenTuple = [undefined, [string, Token]];
+export type TokenTuple = [string, Token];

--- a/packages/design-tokens/docs/utils/buildTokensTableRows.tsx
+++ b/packages/design-tokens/docs/utils/buildTokensTableRows.tsx
@@ -7,9 +7,9 @@ import { TokenRow } from "../types/TokenRow";
 
 export const buildTokensTableRows = (
   columns: TokenColumn[],
-  tokens: Record<string, Record<string, Token>>,
+  tokens: Record<string, Record<string, Token>>
 ): Array<TokenRow> => {
-  const [, tokenEntries] = Object.entries(tokens)[0];
+  const tokenEntries = Object.entries(tokens);
 
   return map(Object.entries(tokenEntries), (token) => {
     return invokeMap(columns, "transform", token) as TokenRow;

--- a/packages/design-tokens/docs/utils/buildTokensTableRows.tsx
+++ b/packages/design-tokens/docs/utils/buildTokensTableRows.tsx
@@ -7,7 +7,7 @@ import { TokenRow } from "../types/TokenRow";
 
 export const buildTokensTableRows = (
   columns: TokenColumn[],
-  tokens: Record<string, Record<string, Token>>
+  tokens: Record<string, Token>
 ): Array<TokenRow> => {
   const tokenEntries = Object.entries(tokens);
 

--- a/packages/design-tokens/docs/utils/buildTokensTableRows.tsx
+++ b/packages/design-tokens/docs/utils/buildTokensTableRows.tsx
@@ -7,11 +7,11 @@ import { TokenRow } from "../types/TokenRow";
 
 export const buildTokensTableRows = (
   columns: TokenColumn[],
-  tokens: Record<string, Token>
+  tokens: Record<string, Token>,
 ): Array<TokenRow> => {
   const tokenEntries = Object.entries(tokens);
 
-  return map(Object.entries(tokenEntries), (token) => {
+  return map(tokenEntries, (token) => {
     return invokeMap(columns, "transform", token) as TokenRow;
   });
 };

--- a/packages/design-tokens/docs/utils/getTokenComment.ts
+++ b/packages/design-tokens/docs/utils/getTokenComment.ts
@@ -1,5 +1,5 @@
 import { TokenEntry } from "../types/TokenEntry";
 
 export const getTokenComment = ([, token]: TokenEntry): string => {
-  return token.comment || "";
+  return token[1].comment || "";
 };

--- a/packages/design-tokens/docs/utils/getTokenComment.ts
+++ b/packages/design-tokens/docs/utils/getTokenComment.ts
@@ -1,5 +1,5 @@
-import { TokenEntry } from "../types/TokenEntry";
+import { TokenTuple } from "../types/TokenTuple";
 
-export const getTokenComment = ([, token]: TokenEntry): string => {
+export const getTokenComment = ([, token]: TokenTuple): string => {
   return token[1].comment || "";
 };

--- a/packages/design-tokens/docs/utils/getTokenComment.ts
+++ b/packages/design-tokens/docs/utils/getTokenComment.ts
@@ -1,5 +1,5 @@
 import { TokenTuple } from "../types/TokenTuple";
 
 export const getTokenComment = ([, token]: TokenTuple): string => {
-  return token[1].comment || "";
+  return token.comment || "";
 };

--- a/packages/design-tokens/docs/utils/getTokenKey.ts
+++ b/packages/design-tokens/docs/utils/getTokenKey.ts
@@ -4,5 +4,7 @@ import { Token } from "../types/Token";
 export const getTokenKey = (
   object: Record<string, Record<string, Token>>,
 ): string => {
+  //console.log(Object.entries(object)[0][1]);
+  //console.log(object)
   return keys(object)[0];
 };

--- a/packages/design-tokens/docs/utils/getTokenKey.ts
+++ b/packages/design-tokens/docs/utils/getTokenKey.ts
@@ -4,7 +4,5 @@ import { Token } from "../types/Token";
 export const getTokenKey = (
   object: Record<string, Record<string, Token>>,
 ): string => {
-  //console.log(Object.entries(object)[0][1]);
-  //console.log(object)
   return keys(object)[0];
 };

--- a/packages/design-tokens/docs/utils/getTokenName.tsx
+++ b/packages/design-tokens/docs/utils/getTokenName.tsx
@@ -1,14 +1,14 @@
 import camelCase from "lodash/camelCase";
 import capitalize from "lodash/capitalize";
-import { TokenEntry } from "../types/TokenEntry";
 import { Token } from "../types/Token";
+import { TokenTuple } from "../types/TokenTuple";
 import { getTokenKey } from "./getTokenKey";
 
 export const getTokenName = (
   tokens: Record<string, Record<string, Token>>,
-): (([suffix]: TokenEntry) => string) => {
+): (([, suffix]: TokenTuple) => string) => {
   const prefix = getTokenKey(tokens);
-  return ([suffix]: TokenEntry): string => {
-    return camelCase(`${prefix}${capitalize(suffix)}`);
+  return ([, suffix]: TokenTuple): string => {
+    return camelCase(`${prefix}${capitalize(suffix[0])}`);
   };
 };

--- a/packages/design-tokens/docs/utils/getTokenName.tsx
+++ b/packages/design-tokens/docs/utils/getTokenName.tsx
@@ -6,9 +6,9 @@ import { getTokenKey } from "./getTokenKey";
 
 export const getTokenName = (
   tokens: Record<string, Record<string, Token>>,
-): (([, suffix]: TokenTuple) => string) => {
+): (([tokenName]: TokenTuple) => string) => {
   const prefix = getTokenKey(tokens);
-  return ([, suffix]: TokenTuple): string => {
-    return camelCase(`${prefix}${capitalize(suffix[0])}`);
+  return ([tokenName]: TokenTuple): string => {
+    return camelCase(`${prefix}${capitalize(tokenName)}`);
   };
 };

--- a/packages/design-tokens/docs/utils/getTokenValue.ts
+++ b/packages/design-tokens/docs/utils/getTokenValue.ts
@@ -1,5 +1,5 @@
 import { TokenTuple } from "../types/TokenTuple";
 
 export const getTokenValue = ([, token]: TokenTuple): string => {
-  return token[1].value;
+  return token.value;
 };

--- a/packages/design-tokens/docs/utils/getTokenValue.ts
+++ b/packages/design-tokens/docs/utils/getTokenValue.ts
@@ -1,5 +1,5 @@
-import { TokenEntry } from "../types/TokenEntry";
+import { TokenTuple } from "../types/TokenTuple";
 
-export const getTokenValue = ([, token]: TokenEntry): string => {
+export const getTokenValue = ([, token]: TokenTuple): string => {
   return token[1].value;
 };

--- a/packages/design-tokens/docs/utils/getTokenValue.ts
+++ b/packages/design-tokens/docs/utils/getTokenValue.ts
@@ -1,5 +1,5 @@
 import { TokenEntry } from "../types/TokenEntry";
 
 export const getTokenValue = ([, token]: TokenEntry): string => {
-  return token.value;
+  return token[1].value;
 };


### PR DESCRIPTION
## Description of the change

JSON files (for instance, color.tokens.json) already have multiple prefixes (color, bg, content, border, ...). This PR aims at enabling Storybook docs to show each token on the respective page.
Related with: https://linear.app/localyze/issue/TREX-1406/parse-pluto-tokens-so-docs-pages-show-all-prefixes-on-it

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
