### PR TITLE
feat: add backdrop to drawer component

### DIFF
--- a/.changeset/red-chefs-sin.md
+++ b/.changeset/red-chefs-sin.md
@@ -1,0 +1,9 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Drawer]:
+
+- Adds backdrop to Drawer component
+- Control with autoFocusOnShow prop whether the Drawer
+  should focus the first focusable element when shown

--- a/packages/components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/components/Drawer/Drawer.stories.tsx
@@ -20,7 +20,7 @@ export default {
 export const Default = (): JSX.Element => {
   const drawer = useDrawerState({ defaultOpen: isChromatic() ? true : false });
   return (
-    <Box.div h="1000px" w="1350px">
+    <Box.div>
       <Button onClick={drawer.toggle} variant="primary">
         Open drawer
       </Button>
@@ -54,7 +54,7 @@ Default.parameters = {
 export const NoPaddingOnBody = (): React.ReactNode => {
   const drawer = useDrawerState({ defaultOpen: isChromatic() ? true : false });
   return (
-    <Box.div h="1000px" w="1350px">
+    <Box.div>
       <Button onClick={drawer.toggle} variant="primary">
         Open drawer
       </Button>
@@ -88,7 +88,7 @@ NoPaddingOnBody.parameters = {
 export const OverflowBodyContent = (): React.ReactNode => {
   const drawer = useDrawerState({ defaultOpen: isChromatic() ? true : false });
   return (
-    <Box.div h="1000px" w="1350px">
+    <Box.div>
       <Button onClick={drawer.toggle} variant="primary">
         Open drawer
       </Button>
@@ -158,7 +158,7 @@ OverflowBodyContent.parameters = {
 export const ReallyLongHeader = (): React.ReactNode => {
   const drawer = useDrawerState({ defaultOpen: isChromatic() ? true : false });
   return (
-    <Box.div h="1000px" w="1350px">
+    <Box.div>
       <Button onClick={drawer.toggle} variant="primary">
         Open drawer
       </Button>
@@ -198,7 +198,7 @@ export const InitialFocus = (): JSX.Element => {
     defaultOpen: isChromatic() ? true : false,
   });
   return (
-    <Box.div h="1000px" w="1350px">
+    <Box.div>
       <Button onClick={drawer.toggle} variant="primary">
         Open drawer
       </Button>

--- a/packages/components/src/components/Drawer/Drawer.tsx
+++ b/packages/components/src/components/Drawer/Drawer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Dialog } from "ariakit/dialog";
 import type { DialogProps } from "ariakit";
+import { styled } from "@localyze-pluto/theme";
 import { Box } from "../../primitives/Box";
 
 export interface DrawerProps extends DialogProps {
@@ -8,18 +9,25 @@ export interface DrawerProps extends DialogProps {
   children: NonNullable<React.ReactNode>;
 }
 
+const StyledBackdrop = styled(Box.div)`
+  background-color: rgba(39, 49, 63, 0.5);
+  backdrop-filter: blur(3px);
+`;
+
 /** A Drawer is a page overlay that displays information and blocks interaction with the page until an action is taken or the Drawer is dismissed. */
 const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
-  ({ children, ...props }, ref) => {
+  ({ children, initialFocusRef, ...props }, ref) => {
     return (
       <Box.div
         as={Dialog}
-        backdrop={false}
+        autoFocusOnShow={initialFocusRef ?? false}
+        backdrop={StyledBackdrop}
         backgroundColor="colorBackground"
         bottom={0}
         boxShadow="shadowStrong"
         display="flex"
         flexDirection="column"
+        initialFocusRef={initialFocusRef}
         maxWidth="34.375rem"
         position="fixed"
         ref={ref}


### PR DESCRIPTION
## Description of the change

This PR adds a styled backdrop to the Drawer component. This component could use the `data-backdrop` attribute already present in `base.tsx` styles, but I decided not to change that right now to avoid impacting other components like Modal. 

Besides that, it fixes an issue with the initialFocus that was focusing the `X` button when the Drawer was opened.


https://github.com/Localitos/pluto/assets/5320963/350032b3-ff20-401e-82ae-582636f3efca



## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
