### PR TITLE
feat: add transition to drawer component

### DIFF
--- a/.changeset/rotten-ravens-nail.md
+++ b/.changeset/rotten-ravens-nail.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[Drawer]: Add transition when opening and closing the drawer

--- a/.changeset/rotten-ravens-nail.md
+++ b/.changeset/rotten-ravens-nail.md
@@ -1,5 +1,5 @@
 ---
-"@localyze-pluto/components": patch
+"@localyze-pluto/components": minor
 ---
 
 [Drawer]: Add transition when opening and closing the drawer

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -1,25 +1,32 @@
 import { render, screen } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
+import { userEvent, UserEvent } from "@testing-library/user-event";
 import React from "react";
 import { Default } from "./Drawer.stories";
 
 const OPEN_DRAWER_TEXT = "Open drawer";
 
 describe("<Drawer />", () => {
+  let user: UserEvent;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
   it("should open and close a drawer using the close drawer button", async () => {
     render(<Default />);
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 
-    await userEvent.click(renderedOpenButton);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await user.click(renderedOpenButton);
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
     const renderedCloseButton = screen.getByLabelText("Close drawer");
     expect(renderedCloseButton).toBeInTheDocument();
 
-    await userEvent.click(renderedCloseButton);
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await user.click(renderedCloseButton);
+    expect(await screen.findByRole("dialog")).not.toBeVisible();
   });
 
   it("should open a drawer and close it using the escape key", async () => {
@@ -27,12 +34,12 @@ describe("<Drawer />", () => {
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 
-    await userEvent.click(renderedOpenButton);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await user.click(renderedOpenButton);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
-    await userEvent.keyboard("{Escape}");
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(await screen.findByRole("dialog")).not.toBeVisible();
   });
 
   it("should open a drawer and close it by clicking an element in the background", async () => {
@@ -40,11 +47,11 @@ describe("<Drawer />", () => {
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 
-    await userEvent.click(renderedOpenButton);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await user.click(renderedOpenButton);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
-    await userEvent.click(renderedOpenButton, { pointerEventsCheck: 1 });
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await user.click(renderedOpenButton);
+    expect(await screen.findByRole("dialog")).not.toBeVisible();
   });
 });

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent, UserEvent } from "@testing-library/user-event";
 import React from "react";
 import { Default } from "./Drawer.stories";
@@ -26,7 +26,9 @@ describe("<Drawer />", () => {
     expect(renderedCloseButton).toBeInTheDocument();
 
     await user.click(renderedCloseButton);
-    expect(await screen.findByRole("dialog")).not.toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).not.toBeVisible();
+    });
   });
 
   it("should open a drawer and close it using the escape key", async () => {
@@ -39,7 +41,9 @@ describe("<Drawer />", () => {
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    expect(await screen.findByRole("dialog")).not.toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).not.toBeVisible();
+    });
   });
 
   it("should open a drawer and close it by clicking an element in the background", async () => {
@@ -52,6 +56,8 @@ describe("<Drawer />", () => {
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
     await user.click(renderedOpenButton);
-    expect(await screen.findByRole("dialog")).not.toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).not.toBeVisible();
+    });
   });
 });

--- a/packages/components/src/components/Drawer/Drawer.tsx
+++ b/packages/components/src/components/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Dialog } from "ariakit/dialog";
+import { Dialog, useDialogState } from "ariakit/dialog";
 import type { DialogProps } from "ariakit";
-import { styled } from "@localyze-pluto/theme";
+import { styled, theme } from "@localyze-pluto/theme";
 import { Box } from "../../primitives/Box";
 
 export interface DrawerProps extends DialogProps {
@@ -12,32 +12,55 @@ export interface DrawerProps extends DialogProps {
 const StyledBackdrop = styled(Box.div)`
   background-color: rgba(39, 49, 63, 0.5);
   backdrop-filter: blur(3px);
+  opacity: 0;
+  transition:
+    opacity 0.5s,
+    backdrop-filter 0.5s;
+
+  &[data-enter] {
+    backdrop-filter: blur(3px);
+    opacity: 1;
+  }
+`;
+
+const StyledDrawer = styled(Box.div)`
+  background-color: ${theme.colors.colorBackground};
+  box-shadow: ${theme.shadows.shadowStrong};
+  display: flex;
+  flex-direction: column;
+  max-width: 34.375rem;
+  position: fixed;
+  right: -100%;
+  top: 0;
+  bottom: 0;
+  transition: right 0.4s;
+  z-index: ${theme.zIndices.zIndex30};
+
+  &[data-enter] {
+    right: 0;
+  }
 `;
 
 /** A Drawer is a page overlay that displays information and blocks interaction with the page until an action is taken or the Drawer is dismissed. */
 const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
-  ({ children, initialFocusRef, ...props }, ref) => {
+  ({ children, state, initialFocusRef, ...props }, ref) => {
+    const internalState = useDialogState({
+      ...state,
+      animated: true,
+    });
+
     return (
-      <Box.div
+      <StyledDrawer
         as={Dialog}
         autoFocusOnShow={initialFocusRef ?? false}
         backdrop={StyledBackdrop}
-        backgroundColor="colorBackground"
-        bottom={0}
-        boxShadow="shadowStrong"
-        display="flex"
-        flexDirection="column"
         initialFocusRef={initialFocusRef}
-        maxWidth="34.375rem"
-        position="fixed"
         ref={ref}
-        right={0}
-        top={0}
-        zIndex="zIndex30"
+        state={internalState}
         {...props}
       >
         {children}
-      </Box.div>
+      </StyledDrawer>
     );
   },
 );


### PR DESCRIPTION
## Description of the change

Adds transition when opening and closing Drawer component. 



https://github.com/Localitos/pluto/assets/5320963/01cc8ca1-7a02-4251-947e-ba50131fc09a





## Testing the change

- [x] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
