### PR TITLE
[NO ISSUE] feat: allow Drawer to receive padding as prop

### DIFF
--- a/.changeset/happy-fans-itch.md
+++ b/.changeset/happy-fans-itch.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+allow Drawer to receive padding as prop

--- a/packages/components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/components/Drawer/Drawer.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 import isChromatic from "chromatic/isChromatic";
+import type { SystemProp, Theme } from "@xstyled/styled-components";
 import { Box } from "../../primitives/Box";
 import { Button } from "../Button";
 import { Paragraph } from "../Paragraph";
@@ -229,5 +230,53 @@ export const InitialFocus = (): JSX.Element => {
 };
 
 InitialFocus.parameters = {
+  chromatic: { delay: 1000, pauseAnimationAtEnd: true },
+};
+
+export const WithPadding = (args: {
+  padding: SystemProp<keyof Theme["space"], Theme>;
+}): JSX.Element => {
+  const buttonRef = React.createRef<HTMLButtonElement>();
+  const drawer = useDrawerState({
+    defaultOpen: isChromatic() ? true : false,
+  });
+  const { padding } = args;
+
+  return (
+    <Box.div>
+      <Button onClick={drawer.toggle} variant="primary">
+        Open drawer
+      </Button>
+      <Drawer initialFocusRef={buttonRef} padding={padding} state={drawer}>
+        <DrawerHeader padding="space0">
+          <DrawerHeading>This is the heading</DrawerHeading>
+        </DrawerHeader>
+        <DrawerBody padding="space0">
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Paragraph>
+            Times feedback the and his consider eating the through position. And
+            leaving than into the her accounts picture they of see her leaders,
+            character text the to and for completely he explanation cheek, for
+            or in the assets different took this treat. Is and the our.
+          </Paragraph>
+          <Button onClick={drawer.toggle} ref={buttonRef} variant="primary">
+            Done
+          </Button>
+        </DrawerBody>
+      </Drawer>
+    </Box.div>
+  );
+};
+
+WithPadding.args = {
+  padding: "space140",
+};
+
+WithPadding.parameters = {
   chromatic: { delay: 1000, pauseAnimationAtEnd: true },
 };

--- a/packages/components/src/components/Drawer/Drawer.tsx
+++ b/packages/components/src/components/Drawer/Drawer.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { Dialog, useDialogState } from "ariakit/dialog";
 import type { DialogProps } from "ariakit";
 import { styled, theme } from "@localyze-pluto/theme";
+import type { SystemProp, Theme } from "@xstyled/styled-components";
 import { Box } from "../../primitives/Box";
 
 export interface DrawerProps extends DialogProps {
   /** The contents of the drawer. */
   children: NonNullable<React.ReactNode>;
+  padding?: SystemProp<keyof Theme["space"], Theme>;
 }
 
 const StyledBackdrop = styled(Box.div)`
@@ -23,7 +25,9 @@ const StyledBackdrop = styled(Box.div)`
   }
 `;
 
-const StyledDrawer = styled(Box.div)`
+const StyledDrawer = styled(Box.div)<{
+  padding?: SystemProp<keyof Theme["space"], Theme>;
+}>`
   background-color: ${theme.colors.colorBackground};
   box-shadow: ${theme.shadows.shadowStrong};
   display: flex;
@@ -34,6 +38,7 @@ const StyledDrawer = styled(Box.div)`
   top: 0;
   bottom: 0;
   transition: right 0.4s;
+  padding: ${({ padding }) => padding ?? "space0"};
   z-index: ${theme.zIndices.zIndex30};
 
   &[data-enter] {
@@ -43,7 +48,7 @@ const StyledDrawer = styled(Box.div)`
 
 /** A Drawer is a page overlay that displays information and blocks interaction with the page until an action is taken or the Drawer is dismissed. */
 const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
-  ({ children, state, initialFocusRef, ...props }, ref) => {
+  ({ children, state, initialFocusRef, padding, ...props }, ref) => {
     const internalState = useDialogState({
       ...state,
       animated: true,
@@ -55,6 +60,7 @@ const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
         autoFocusOnShow={initialFocusRef ?? false}
         backdrop={StyledBackdrop}
         initialFocusRef={initialFocusRef}
+        padding={padding}
         ref={ref}
         state={internalState}
         {...props}

--- a/packages/components/src/components/Drawer/DrawerBody.tsx
+++ b/packages/components/src/components/Drawer/DrawerBody.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { SystemProp, Theme } from "@xstyled/styled-components";
 import { Box } from "../../primitives/Box";
 
 export interface DrawerBodyProps
@@ -6,7 +7,7 @@ export interface DrawerBodyProps
   /** The contents of the drawer body. */
   children: NonNullable<React.ReactNode>;
   /** Sets the padding of the drawer body. */
-  padding?: "space0" | "space60";
+  padding?: SystemProp<keyof Theme["space"], Theme>;
 }
 
 /** The body content area of the drawer. */

--- a/packages/components/src/components/Drawer/DrawerHeader.tsx
+++ b/packages/components/src/components/Drawer/DrawerHeader.tsx
@@ -7,17 +7,18 @@ export interface DrawerHeaderProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {
   /** The contents of the drawer header */
   children: NonNullable<React.ReactNode>;
+  padding?: "space0" | "space60";
 }
 
 /** The header content area of the drawer. */
 const DrawerHeader = React.forwardRef<HTMLDivElement, DrawerHeaderProps>(
-  ({ children, ...props }, ref) => {
+  ({ children, padding = "space60", ...props }, ref) => {
     return (
       <Box.div
         display="flex"
         gap="space30"
         justifyContent="space-between"
-        padding="space60"
+        padding={padding}
         ref={ref}
         {...props}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -4399,11 +4399,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/scheduler@*":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.23.0.tgz#0a6655b3e2708eaabca00b7372fafd7a792a7b09"
-  integrity sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==
-
 "@types/semver@^7.3.12", "@types/semver@^7.3.4", "@types/semver@^7.5.0":
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.7.tgz#326f5fdda70d13580777bcaa1bc6fa772a5aef0e"


### PR DESCRIPTION
## Description of the change

Goal of the PR is to allow the Drawer component to receive padding as a Prop, therefore increasing its flexibility and allowing to meet the design goals stated here, where padding is 24px (space70).

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
