### PR TITLE
[NO ISSUE] fix: export UtilityCard to be used externally

### DIFF
--- a/.changeset/tough-fans-tap.md
+++ b/.changeset/tough-fans-tap.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+export UtilityCard to be used externally

--- a/packages/components/src/components/UtilityCard/UtilityCard.stories.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import React from "react";
 import { Box } from "../../primitives/Box";
-import { UtilityCard, InteractiveElementType } from "./UtilityCard";
+import { UtilityCard, InteractiveElementTypeUtilityCard } from "./UtilityCard";
 
 export default {
   component: UtilityCard,
@@ -39,7 +39,7 @@ CardWithBadge.args = {
 export const ClickableCard: Story = Template.bind({});
 ClickableCard.args = {
   ...defaultProps,
-  interactiveElementType: InteractiveElementType.Card,
+  interactiveElementType: InteractiveElementTypeUtilityCard.Card,
   onClick,
 };
 

--- a/packages/components/src/components/UtilityCard/UtilityCard.test.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.test.tsx
@@ -4,7 +4,7 @@ import { userEvent } from "@testing-library/user-event";
 import {
   UtilityCard,
   UtilityCardProps,
-  InteractiveElementType,
+  InteractiveElementTypeUtilityCard,
 } from "./UtilityCard";
 
 const onClick = jest.fn();
@@ -35,7 +35,7 @@ const renderCardWithBadge = (): RenderResult => {
 const renderClickableCard = (): RenderResult => {
   return render(
     <UtilityCardMock
-      interactiveElementType={InteractiveElementType.Card}
+      interactiveElementType={InteractiveElementTypeUtilityCard.Card}
       onClick={onClick}
     />,
   );

--- a/packages/components/src/components/UtilityCard/UtilityCard.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.tsx
@@ -4,7 +4,7 @@ import { Badge } from "../Badge";
 import { Icon } from "../Icon";
 import { Text } from "../../primitives/Text";
 
-export enum InteractiveElementType {
+export enum InteractiveElementTypeUtilityCard {
   Card = "card",
 }
 
@@ -14,7 +14,7 @@ export type UtilityCardProps = {
   /** Sets the title to be rendered as h2 */
   title: string;
   /** Sets the type of the clickable element */
-  interactiveElementType?: InteractiveElementType;
+  interactiveElementType?: InteractiveElementTypeUtilityCard;
   /** Text describing the kind of category provided */
   categoryTag: string;
   /** Text describing the current status of the category as a badge */
@@ -45,7 +45,7 @@ export const UtilityCard: React.FC<UtilityCardProps> = ({
   onClick,
 }) => {
   const isCardInteractive =
-    InteractiveElementType.Card === interactiveElementType;
+    InteractiveElementTypeUtilityCard.Card === interactiveElementType;
 
   const interactiveElementProps = {
     onClick,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -35,5 +35,6 @@ export * from "./components/Tabs";
 export * from "./components/Textarea";
 export * from "./components/Toast";
 export * from "./components/Tooltip";
+export * from "./components/UtilityCard";
 export * from "./primitives/Box";
 export * from "./primitives/Text";


### PR DESCRIPTION
## Description of the change

Allow UtilityCard to be used outside of Pluto. As of now, due to a missing export, it's an unrecognized import.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
