### PR TITLE
fix: avoid click on button to close

### DIFF
--- a/.changeset/wicked-actors-ring.md
+++ b/.changeset/wicked-actors-ring.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fix Drawer test

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -56,7 +56,7 @@ describe("<Drawer />", () => {
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
-    await user.click(renderedOpenButton);
+    await user.click(await screen.findByRole("presentation"));
     await waitFor(() => {
       expect(screen.getByRole("dialog")).not.toBeVisible();
     });

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -48,6 +48,7 @@ describe("<Drawer />", () => {
 
   it("should open a drawer and close it by clicking an element in the background", async () => {
     render(<Default />);
+
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 


### PR DESCRIPTION
## Description of the change
- Change the place where the Drawer test has a click in order to fix flakiness

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Non-Breaking Change (change to existing functionality)

