### PR TITLE
fix(components): Add transparent background for PaginationButton

### DIFF
--- a/.changeset/small-hounds-destroy.md
+++ b/.changeset/small-hounds-destroy.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+The background of pagination buttons not being the current page is now transparent.

--- a/packages/components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/components/src/components/Pagination/Pagination.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import React from "react";
+import { Box } from "../../primitives/Box";
 import { Pagination } from "./Pagination";
 
 const meta: Meta<typeof Pagination> = {
@@ -11,7 +12,7 @@ const meta: Meta<typeof Pagination> = {
 export default meta;
 type Story = StoryObj<typeof Pagination>;
 
-const BasicPagination = (): JSX.Element => {
+const BasicPagination = (): React.JSX.Element => {
   const [currentPage, setCurrentPage] = React.useState(5);
   return (
     <Pagination
@@ -23,7 +24,7 @@ const BasicPagination = (): JSX.Element => {
 };
 
 export const Default: Story = {
-  render: (): JSX.Element => <BasicPagination />,
+  render: (): React.JSX.Element => <BasicPagination />,
 };
 
 Default.parameters = {
@@ -33,7 +34,7 @@ Default.parameters = {
   },
 };
 
-const PaginationWithLotsOfPages = (): JSX.Element => {
+const PaginationWithLotsOfPages = (): React.JSX.Element => {
   const [currentPage, setCurrentPage] = React.useState(333);
   return (
     <Pagination
@@ -45,10 +46,10 @@ const PaginationWithLotsOfPages = (): JSX.Element => {
 };
 
 export const WithLotsOfPages: Story = {
-  render: (): JSX.Element => <PaginationWithLotsOfPages />,
+  render: (): React.JSX.Element => <PaginationWithLotsOfPages />,
 };
 
-const PaginationWithMorePageNeighbors = (): JSX.Element => {
+const PaginationWithMorePageNeighbors = (): React.JSX.Element => {
   const [currentPage, setCurrentPage] = React.useState(333);
   return (
     <Pagination
@@ -61,5 +62,13 @@ const PaginationWithMorePageNeighbors = (): JSX.Element => {
 };
 
 export const WithMorePageNeighbors: Story = {
-  render: (): JSX.Element => <PaginationWithMorePageNeighbors />,
+  render: (): React.JSX.Element => <PaginationWithMorePageNeighbors />,
+};
+
+export const WithContainerBackground: Story = {
+  render: (): React.JSX.Element => (
+    <Box.div backgroundColor="colorBackgroundWeaker" padding="space40">
+      <PaginationWithLotsOfPages />
+    </Box.div>
+  ),
 };

--- a/packages/components/src/components/Pagination/PaginationButton.tsx
+++ b/packages/components/src/components/Pagination/PaginationButton.tsx
@@ -17,12 +17,12 @@ export const PaginationButton = ({
       <Box.button
         alignItems="center"
         appearance="none"
-        aria-current={isCurrentPage ? true : false}
+        aria-current={isCurrentPage}
         aria-label={
           isCurrentPage ? `Current Page, Page ${page}` : `Goto Page ${page}`
         }
         backgroundColor={{
-          _: isCurrentPage ? "colorBackgroundInfo" : "colorBackground",
+          _: isCurrentPage ? "colorBackgroundInfo" : "transparent",
           hover: "colorBackgroundInfo",
           focus: "colorBackgroundInfo",
         }}


### PR DESCRIPTION
## Description of the change

Fix the background of `PaginationButton`s that are not the current page. [According to Hanna](https://localyzeteam.slack.com/archives/C03DUMP3XD4/p1713269851623759?thread_ts=1713269362.203909&cid=C03DUMP3XD4) they should be transparent.

### Before
![Screenshot_20240416_213254](https://github.com/Localitos/pluto/assets/6059188/fee6cc03-99a9-4b39-ba10-88965a96d5a3)

### After
![Screenshot_20240416_213216](https://github.com/Localitos/pluto/assets/6059188/60739bb0-469e-4dba-af39-a57ad41410f5)


