### PR TITLE
fix: remove drawer animation on tests

### DIFF
--- a/.changeset/four-needles-argue.md
+++ b/.changeset/four-needles-argue.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Remove transition on Drawer tests to decrease errors

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -48,12 +48,9 @@ describe("<Drawer />", () => {
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    await waitFor(
-      () => {
-        expect(screen.getByRole("dialog")).not.toBeVisible();
-      },
-      { timeout: 1000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).not.toBeVisible();
+    });
   });
 
   it("should open a drawer and close it by clicking an element in the background", async () => {

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -7,7 +7,7 @@ import { Default } from "./Drawer.stories";
 const OPEN_DRAWER_TEXT = "Open drawer";
 
 const StyledDrawer = styled(Default)`
-  * > {
+  * {
     transition: none !important;
   }
 `;

--- a/packages/components/src/components/Drawer/Drawer.test.tsx
+++ b/packages/components/src/components/Drawer/Drawer.test.tsx
@@ -1,9 +1,16 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent, UserEvent } from "@testing-library/user-event";
 import React from "react";
+import styled from "styled-components";
 import { Default } from "./Drawer.stories";
 
 const OPEN_DRAWER_TEXT = "Open drawer";
+
+const StyledDrawer = styled(Default)`
+  * > {
+    transition: none !important;
+  }
+`;
 
 describe("<Drawer />", () => {
   let user: UserEvent;
@@ -13,7 +20,7 @@ describe("<Drawer />", () => {
   });
 
   it("should open and close a drawer using the close drawer button", async () => {
-    render(<Default />);
+    render(<StyledDrawer />);
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 
@@ -32,7 +39,7 @@ describe("<Drawer />", () => {
   });
 
   it("should open a drawer and close it using the escape key", async () => {
-    render(<Default />);
+    render(<StyledDrawer />);
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();
 
@@ -41,13 +48,16 @@ describe("<Drawer />", () => {
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).not.toBeVisible();
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByRole("dialog")).not.toBeVisible();
+      },
+      { timeout: 1000 },
+    );
   });
 
   it("should open a drawer and close it by clicking an element in the background", async () => {
-    render(<Default />);
+    render(<StyledDrawer />);
 
     const renderedOpenButton = screen.getByText(OPEN_DRAWER_TEXT);
     expect(renderedOpenButton).toBeInTheDocument();


### PR DESCRIPTION
## Description of the change

- Add an element wrapping Drawer to remove transition on tests

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
