### PR TITLE
chore: add colorTextStrongest as an option to Heading color

### DIFF
--- a/.changeset/lemon-ties-chew.md
+++ b/.changeset/lemon-ties-chew.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add `colorTextStrongest` as option to Heading

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -33,7 +33,8 @@ type HeadingFontColors =
   | "colorTextHeading"
   | "colorTextHeadingStrong"
   | "colorTextHeadingStronger"
-  | "colorTextInverse";
+  | "colorTextInverse"
+  | "colorTextStrongest";
 
 export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   /** Sets the HTML element on render. */


### PR DESCRIPTION
## Description of the change

- Add `colorTextStrongest` as option to Heading

## Type of change

- [x] Non-Breaking Change (change to existing functionality)
