### PR TITLE
feat(components): add isRounded property to ContentCard

### DIFF
--- a/.changeset/modern-queens-sneeze.md
+++ b/.changeset/modern-queens-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add isRounded property to Content Card

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -86,6 +86,19 @@ PortraitImage.args = {
   imageSrc: "/images/beach-porto-rico.jpg",
 };
 
+export const SquareImage: Story = Template.bind({});
+SquareImage.args = {
+  ...defaultProps,
+  isRounded: false,
+};
+
+export const SquareImagePortrait: Story = Template.bind({});
+SquareImagePortrait.args = {
+  ...defaultProps,
+  imagePosition: "top",
+  isRounded: false,
+};
+
 export const InList = (): JSX.Element => {
   return (
     <Box.ul

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -47,6 +47,8 @@ export type ContentCardProps = {
   ctaText?: string;
   /** Used by StyledComponents to render the component as a specific tag. If href is passed it'll be rendered as "a" */
   as?: React.ComponentProps<typeof Box.div>["as"];
+  /** Sets the pre-defined border radius to the card */
+  isRounded?: boolean;
 };
 
 const backgroundColor: Record<Background, BoxProps["backgroundColor"]> = {
@@ -71,6 +73,7 @@ export const ContentCard = ({
   background = "default",
   target,
   as = "div",
+  isRounded = true,
 }: ContentCardProps): JSX.Element => {
   const isImageOnTop = imagePosition === "top";
 
@@ -113,7 +116,7 @@ export const ContentCard = ({
       as={isCardInteractive ? "a" : as}
       backgroundColor={backgroundColor[background]}
       border={0}
-      borderRadius="borderRadius40"
+      borderRadius={isRounded ? "borderRadius40" : ""}
       boxShadow={
         isCardInteractive && {
           _: "none",
@@ -206,7 +209,7 @@ export const ContentCard = ({
       </Box.div>
       <Box.div
         alignItems="center"
-        borderRadius={imageBorderRadius[imagePosition]}
+        borderRadius={isRounded ? imageBorderRadius[imagePosition] : ""}
         display="flex"
         maxH={isImageOnTop ? 180 : { _: 180, md: "unset" }}
         overflow="hidden"

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -47,7 +47,7 @@ export type ContentCardProps = {
   ctaText?: string;
   /** Used by StyledComponents to render the component as a specific tag. If href is passed it'll be rendered as "a" */
   as?: React.ComponentProps<typeof Box.div>["as"];
-  /** Sets the pre-defined border radius to the card */
+  /** Sets the pre-defined border radius on the card */
   isRounded?: boolean;
 };
 

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -116,7 +116,7 @@ export const ContentCard = ({
       as={isCardInteractive ? "a" : as}
       backgroundColor={backgroundColor[background]}
       border={0}
-      borderRadius={isRounded ? "borderRadius40" : ""}
+      borderRadius={isRounded ? "borderRadius40" : undefined}
       boxShadow={
         isCardInteractive && {
           _: "none",
@@ -209,7 +209,7 @@ export const ContentCard = ({
       </Box.div>
       <Box.div
         alignItems="center"
-        borderRadius={isRounded ? imageBorderRadius[imagePosition] : ""}
+        borderRadius={isRounded ? imageBorderRadius[imagePosition] : undefined}
         display="flex"
         maxH={isImageOnTop ? 180 : { _: 180, md: "unset" }}
         overflow="hidden"


### PR DESCRIPTION
## Description of the change

Write out a good description of the change. A screenshot or video will also be helpful.
- Add `isRounded` property to Content Card making it possible to remove border radius

![Screen Shot 2024-05-02 at 12 03 59](https://github.com/Localitos/pluto/assets/2047941/13df4068-2b33-4982-a8e8-9b2804da902e)

## Type of change

- [x] New feature (non-breaking change that adds functionality)

