### PR TITLE
fix(components): add button with 100% width correctly to menu

### DIFF
--- a/.changeset/neat-wasps-yell.md
+++ b/.changeset/neat-wasps-yell.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Fix menu buttons width by passing a styled button with 100% width to it

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -32,6 +32,10 @@ const VerticalEllipsisButton = (
   />
 );
 
+const FullWidthButton = ({ ...props }) => (
+  <Button fullWidth variant="ghost" {...props} />
+);
+
 /** A menu is a button element that opens a menu with items. */
 const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
   ({ menuButton, items }, ref) => {
@@ -75,7 +79,7 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
                 >
                   <Box.button
                     alignItems="center"
-                    as={Button}
+                    as={FullWidthButton}
                     disabled={disabled}
                     justifyContent="flex-start"
                     onClick={onClick}
@@ -86,8 +90,10 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
                     w="100%"
                   >
                     <Box.span
+                      backgroundColor="bgInfo"
                       color={disabled ? "colorText" : "colorTextStrongest"}
                       textAlign="left"
+                      w="100%"
                     >
                       {label}
                     </Box.span>

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -90,7 +90,6 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
                     w="100%"
                   >
                     <Box.span
-                      backgroundColor="bgInfo"
                       color={disabled ? "colorText" : "colorTextStrongest"}
                       textAlign="left"
                       w="100%"


### PR DESCRIPTION
## Description of the change
- Add 100% width to the button on menu avoiding to be overwritten by previous button style

background added for pure debugging

before:
![Screen Shot 2024-05-13 at 08 00 20](https://github.com/Localitos/pluto/assets/2047941/a1cda22d-8939-4669-8c32-7af369fc2a06)


after:
![Screen Shot 2024-05-13 at 08 00 06](https://github.com/Localitos/pluto/assets/2047941/dec1a344-ce64-44ab-8e05-4458b178b0b7)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
