### PR TITLE
chore: make ContentCard maxWidth changeable, fix button width, remove unused prop

### DIFF
--- a/.changeset/olive-moons-smoke.md
+++ b/.changeset/olive-moons-smoke.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Change ContentCard to handle max-width, fix button width, remove unused isRounded prop

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -86,19 +86,6 @@ PortraitImage.args = {
   imageSrc: "/images/beach-porto-rico.jpg",
 };
 
-export const SquareImage: Story = Template.bind({});
-SquareImage.args = {
-  ...defaultProps,
-  isRounded: false,
-};
-
-export const SquareImagePortrait: Story = Template.bind({});
-SquareImagePortrait.args = {
-  ...defaultProps,
-  imagePosition: "top",
-  isRounded: false,
-};
-
 export const InList = (): JSX.Element => {
   return (
     <Box.ul

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -47,8 +47,8 @@ export type ContentCardProps = {
   ctaText?: string;
   /** Used by StyledComponents to render the component as a specific tag. If href is passed it'll be rendered as "a" */
   as?: React.ComponentProps<typeof Box.div>["as"];
-  /** Sets the pre-defined border radius on the card */
-  isRounded?: boolean;
+  /** Overwrites default maxWidth */
+  maxWidth?: BoxProps["maxW"];
 };
 
 const backgroundColor: Record<Background, BoxProps["backgroundColor"]> = {
@@ -73,7 +73,7 @@ export const ContentCard = ({
   background = "default",
   target,
   as = "div",
-  isRounded = true,
+  maxWidth,
 }: ContentCardProps): JSX.Element => {
   const isImageOnTop = imagePosition === "top";
 
@@ -84,7 +84,7 @@ export const ContentCard = ({
     },
   };
 
-  const maxWidth = {
+  const maxWidthDefault = {
     top: 350,
     right: {
       _: 350,
@@ -116,7 +116,7 @@ export const ContentCard = ({
       as={isCardInteractive ? "a" : as}
       backgroundColor={backgroundColor[background]}
       border={0}
-      borderRadius={isRounded ? "borderRadius40" : undefined}
+      borderRadius={"borderRadius40"}
       boxShadow={
         isCardInteractive && {
           _: "none",
@@ -130,7 +130,7 @@ export const ContentCard = ({
       fontFamily="fontFamilyNotoSans"
       justifyContent="space-between"
       maxH={maxHeight[imagePosition]}
-      maxW={maxWidth[imagePosition]}
+      maxW={maxWidth || maxWidthDefault[imagePosition]}
       padding="space0"
       textDecoration="none"
       {...(isCardInteractive ? interactiveElementProps : {})}
@@ -190,7 +190,7 @@ export const ContentCard = ({
           gap="space50"
         >
           {InteractiveElementType.Button === interactiveElementType && (
-            <Box.div w={isImageOnTop ? "50%" : { _: "100%", md: "50%" }}>
+            <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
               <Button
                 as="a"
                 fullWidth
@@ -209,7 +209,7 @@ export const ContentCard = ({
       </Box.div>
       <Box.div
         alignItems="center"
-        borderRadius={isRounded ? imageBorderRadius[imagePosition] : undefined}
+        borderRadius={imageBorderRadius[imagePosition]}
         display="flex"
         maxH={isImageOnTop ? 180 : { _: 180, md: "unset" }}
         overflow="hidden"


### PR DESCRIPTION
## Description of the change

- Add a max-width prop to make it configurable
- Fix button width when image is on top
- Remove unused isRounded property

before:

![Screen Shot 2024-06-07 at 08 28 42](https://github.com/Localitos/pluto/assets/2047941/59e756f9-a760-4ede-9a01-8faf20874be1)

after:

![Screen Shot 2024-06-07 at 08 35 09](https://github.com/Localitos/pluto/assets/2047941/354dbd6f-91d7-46eb-9628-baf9348fdde7)


## Type of change
- [x] Non-Breaking Change (change to existing functionality)


### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
