### PR TITLE
chore: change ctaText to callToAction allowing any ReactNode on ContentCard call to action

### DIFF
--- a/.changeset/warm-cups-behave.md
+++ b/.changeset/warm-cups-behave.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": major
+---
+
+Change ctaText property to callToAction allowing custom react nodes

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import React from "react";
 import { Box } from "../../primitives/Box";
+import { Button } from "../Button";
 import { ContentCard, InteractiveElementType } from "./ContentCard";
 
 export default {
@@ -34,14 +35,14 @@ export const WithButton: Story = Template.bind({});
 WithButton.args = {
   ...defaultProps,
   interactiveElementType: InteractiveElementType.Button,
-  ctaText: "Go to Page",
+  callToAction: "Go to Page",
   href,
 };
 
 export const WithAnchor: Story = Template.bind({});
 WithAnchor.args = {
   ...defaultProps,
-  ctaText: "This is an Anchor",
+  callToAction: "This is an Anchor",
   interactiveElementType: InteractiveElementType.Anchor,
   href,
 };
@@ -58,7 +59,7 @@ WithTargetBlank.args = {
   ...defaultProps,
   interactiveElementType: InteractiveElementType.Anchor,
   href,
-  ctaText: "This is an Anchor",
+  callToAction: "This is an Anchor",
   target: "_blank",
 };
 
@@ -72,6 +73,18 @@ export const ImageOnTop: Story = Template.bind({});
 ImageOnTop.args = {
   ...defaultProps,
   imagePosition: "top",
+};
+
+export const CustomCta: Story = Template.bind({});
+CustomCta.args = {
+  ...defaultProps,
+  callToAction: (
+    <Button fullWidth loading variant="primary">
+      Custom CTA
+    </Button>
+  ),
+  imagePosition: "top",
+  interactiveElementType: InteractiveElementType.Custom,
 };
 
 export const WithIcon: Story = Template.bind({});

--- a/packages/components/src/components/ContentCard/ContentCard.test.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.test.tsx
@@ -63,7 +63,7 @@ describe("<ContentCard>", () => {
   it('renders button as link when interactive element type is "button"', () => {
     render(
       <ContentCardMock
-        ctaText="Go to Page"
+        callToAction="Go to Page"
         href={HREF}
         interactiveElementType={InteractiveElementType.Button}
       />,
@@ -73,10 +73,30 @@ describe("<ContentCard>", () => {
     expect(cardButton).toHaveAttribute("href", HREF);
   });
 
+  it("renders custom call to action", async () => {
+    const user = userEvent.setup();
+    const onClickSpy = jest.fn();
+
+    render(
+      <ContentCardMock
+        callToAction={<button onClick={onClickSpy}>anything!</button>}
+        href={HREF}
+        interactiveElementType={InteractiveElementType.Custom}
+      />,
+    );
+
+    const cardButton = screen.getByRole("button", { name: "anything!" });
+    expect(cardButton).toBeVisible();
+
+    await user.click(cardButton);
+
+    expect(onClickSpy).toHaveBeenCalled();
+  });
+
   it('renders anchor as link when interactive element type is "anchor"', () => {
     render(
       <ContentCardMock
-        ctaText="This is an Anchor"
+        callToAction="This is an Anchor"
         href={HREF}
         interactiveElementType={InteractiveElementType.Anchor}
       />,
@@ -89,7 +109,7 @@ describe("<ContentCard>", () => {
   it("renders interactive element with target blank when target is passed", () => {
     render(
       <ContentCardMock
-        ctaText="This is an Anchor"
+        callToAction="This is an Anchor"
         href={HREF}
         interactiveElementType={InteractiveElementType.Anchor}
         target="_blank"

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { Box, BoxProps } from "../../primitives/Box";
 import { Heading } from "../Heading";
 import { Text } from "../../primitives/Text";
@@ -14,6 +14,7 @@ export enum InteractiveElementType {
   Anchor = "anchor",
   Button = "button",
   Card = "card",
+  Custom = "custom",
 }
 
 export type ContentCardProps = {
@@ -44,7 +45,7 @@ export type ContentCardProps = {
   /** Callback to be used when the interactive element is clicked */
   onClick?: React.MouseEventHandler;
   /** Sets the text to the interactive element when it's anchor or button */
-  ctaText?: string;
+  callToAction?: ReactNode | string;
   /** Used by StyledComponents to render the component as a specific tag. If href is passed it'll be rendered as "a" */
   as?: React.ComponentProps<typeof Box.div>["as"];
   /** Overwrites default maxWidth */
@@ -60,7 +61,7 @@ const backgroundColor: Record<Background, BoxProps["backgroundColor"]> = {
 export const ContentCard = ({
   href,
   onClick,
-  ctaText,
+  callToAction,
   interactiveElementType,
   imageSrc,
   imageAlt,
@@ -197,13 +198,19 @@ export const ContentCard = ({
                 variant="secondary"
                 {...interactiveElementProps}
               >
-                {ctaText}
+                {callToAction}
               </Button>
             </Box.div>
           )}
 
           {InteractiveElementType.Anchor === interactiveElementType && (
-            <Anchor {...interactiveElementProps}>{ctaText || ""}</Anchor>
+            <Anchor {...interactiveElementProps}>{callToAction || ""}</Anchor>
+          )}
+
+          {InteractiveElementType.Custom === interactiveElementType && (
+            <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
+              {callToAction}
+            </Box.div>
           )}
         </Box.div>
       </Box.div>


### PR DESCRIPTION
## Description of the change
- Changes cta prop to callToAction allowing any ReactNode to be passed

<img width="375" alt="Screen Shot 2024-07-01 at 18 30 45" src="https://github.com/Localitos/pluto/assets/2047941/32a2d7f4-669d-4794-abe5-f6c53516cc43">


## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
