### PR TITLE
chore(components): allow Paragraph to use m0 and m6 as margin

### DIFF
--- a/.changeset/perfect-bananas-play.md
+++ b/.changeset/perfect-bananas-play.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Add m0 and m6 tokens as possible margins to Paragraph component

--- a/packages/components/src/components/Paragraph/Paragraph.tsx
+++ b/packages/components/src/components/Paragraph/Paragraph.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { SystemProp, Theme } from "@xstyled/styled-components";
 import { Text } from "../../primitives/Text";
 
-type ParagraphMarginOptions = "space0" | "space70";
+type ParagraphMarginOptions = "m0" | "m6" | "space0" | "space70";
 type ParagraphSizeOptions = "large" | "medium" | "small";
 
 export interface ParagraphProps


### PR DESCRIPTION
## Description of the change

- Add m0 and m6 tokens as possible margins to Paragraph component

## Type of change

- [x] Non-Breaking Change (change to existing functionality)


### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
