### PR TITLE
fix(components): remove token limitations from some components

### DIFF
--- a/.changeset/happy-moons-speak.md
+++ b/.changeset/happy-moons-speak.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Fix interfaces to Label, OrderedList, UnorderedList, Paragraph, Td

--- a/packages/components/src/components/Label/Label.tsx
+++ b/packages/components/src/components/Label/Label.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Box, BoxProps } from "../../primitives/Box";
 
-export interface LabelProps extends BoxProps {
+export interface LabelProps
+  extends Omit<React.HTMLAttributes<HTMLLabelElement>, "color">,
+    BoxProps {
   /** Adjusts the cursor to be not-allowed. */
   disabled?: boolean;
   /** Use and `id` to tie a label directly to a specific form element. */

--- a/packages/components/src/components/List/OrderedList.tsx
+++ b/packages/components/src/components/List/OrderedList.tsx
@@ -2,7 +2,9 @@ import styled from "@xstyled/styled-components";
 import React from "react";
 import { Box, BoxProps } from "../../primitives/Box";
 
-export interface OrderedListProps extends BoxProps {
+export interface OrderedListProps
+  extends Omit<React.HTMLAttributes<HTMLOListElement>, "color">,
+    BoxProps {
   /** The list items */
   children: NonNullable<React.ReactNode>;
 }

--- a/packages/components/src/components/List/UnorderedList.tsx
+++ b/packages/components/src/components/List/UnorderedList.tsx
@@ -2,7 +2,9 @@ import styled from "@xstyled/styled-components";
 import React from "react";
 import { Box, BoxProps } from "../../primitives/Box";
 
-export interface UnorderedListProps extends BoxProps {
+export interface UnorderedListProps
+  extends Omit<React.HTMLAttributes<HTMLUListElement>, "color">,
+    BoxProps {
   /** The list items */
   children: NonNullable<React.ReactNode>;
 }

--- a/packages/components/src/components/Paragraph/Paragraph.tsx
+++ b/packages/components/src/components/Paragraph/Paragraph.tsx
@@ -4,7 +4,9 @@ import { Box, BoxProps } from "../../primitives/Box";
 
 type ParagraphSizeOptions = "large" | "medium" | "small";
 
-export interface ParagraphProps extends BoxProps {
+export interface ParagraphProps
+  extends Omit<React.HTMLAttributes<HTMLParagraphElement>, "color">,
+    BoxProps {
   /** The contents of the paragraph. Can be text or valid text related HTML, i.e. anchor and strong elements. */
   children: NonNullable<React.ReactNode>;
   /** Changes the font-size and line-height of the Paragraph. */

--- a/packages/components/src/components/Table/Td.tsx
+++ b/packages/components/src/components/Table/Td.tsx
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 import { Box, BoxProps } from "../../primitives/Box";
 import { TableContext } from "./TableContext";
 
-export interface TdProps extends BoxProps {
+export interface TdProps
+  extends Omit<React.HTMLAttributes<HTMLTableCellElement>, "color">,
+    BoxProps {
   /** The valid HTML contents of the table cell. */
   children?: React.ReactNode;
   /** Used to make a cell span over multiple columns. */


### PR DESCRIPTION
## Description of the change
- Apply the same interface fix to Label, OrderedList, UnorderedList, Paragraph, Td in order to allow things as `id` 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Development

- [x] All tests related to the changed code pass in development
