### PR TITLE
chore(design-tokens): add prefix space tokens as deprecated

### DIFF
--- a/.changeset/plenty-rats-love.md
+++ b/.changeset/plenty-rats-love.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/design-tokens": minor
+---
+
+Add space prefix tokens as deprecated, change config to add comment on the file

--- a/packages/design-tokens/config.js
+++ b/packages/design-tokens/config.js
@@ -9,14 +9,30 @@ const colorTokensPath = "src/tokens/color.tokens.json";
 
 const handleLodashJavascript = (token) => {
   const { attributes } = token;
+  let comment = `/** ${token.comment} */`;
 
-  return `export const ${camelCase(attributes.category)}${replace(upperFirst(attributes.type), "-", "")} = "${token.value}" /** ${token.comment} */`;
+  if (token.deprecated) {
+    comment = `/**
+ * @deprecated ${token.deprecated_comment}
+ */`;
+  }
+
+  return `${comment}
+export const ${camelCase(attributes.category)}${replace(upperFirst(attributes.type), "-", "")} = "${token.value}"`;
 };
 
 const handleLodashTypescript = (token) => {
   const { attributes } = token;
 
-  return `/* ${token.value} */
+  let comment = `/* ${token.value} */`;
+
+  if (token.deprecated) {
+    comment = `/**
+ * @deprecated ${token.deprecated_comment}
+ */`;
+  }
+
+  return `${comment}
 export const ${camelCase(attributes.category)}${replace(upperFirst(attributes.type), "-", "")}: string`;
 };
 

--- a/packages/design-tokens/src/tokens/space.tokens.json
+++ b/packages/design-tokens/src/tokens/space.tokens.json
@@ -132,163 +132,243 @@
   "space": {
     "0": {
       "value": "0rem",
-      "comment": "0px"
+      "comment": "0px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "10": {
       "value": "0.125rem",
-      "comment": "2px"
+      "comment": "2px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "20": {
       "value": "0.25rem",
-      "comment": "4px"
+      "comment": "4px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "25": {
       "value": "0.4rem",
-      "comment": "6px"
+      "comment": "6px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "30": {
       "value": "0.5rem",
-      "comment": "8px"
+      "comment": "8px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "40": {
       "value": "0.75rem",
-      "comment": "12px"
+      "comment": "12px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "50": {
       "value": "1rem",
-      "comment": "16px"
+      "comment": "16px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "60": {
       "value": "1.25rem",
-      "comment": "20px"
+      "comment": "20px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "70": {
       "value": "1.5rem",
-      "comment": "24px"
+      "comment": "24px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "80": {
       "value": "1.75rem",
-      "comment": "28px"
+      "comment": "28px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "90": {
       "value": "2rem",
-      "comment": "32px"
+      "comment": "32px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "100": {
       "value": "2.25rem",
-      "comment": "36px"
+      "comment": "36px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "110": {
       "value": "2.5rem",
-      "comment": "40px"
+      "comment": "40px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "120": {
       "value": "3rem",
-      "comment": "48px"
+      "comment": "48px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "130": {
       "value": "3.25rem",
-      "comment": "52px"
+      "comment": "52px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "140": {
       "value": "3.5rem",
-      "comment": "56px"
+      "comment": "56px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "150": {
       "value": "3.75rem",
-      "comment": "60px"
+      "comment": "60px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "160": {
       "value": "4.5rem",
-      "comment": "72px"
+      "comment": "72px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "170": {
       "value": "5rem",
-      "comment": "80px"
+      "comment": "80px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "180": {
       "value": "6rem",
-      "comment": "96px"
+      "comment": "96px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "190": {
       "value": "6.25rem",
-      "comment": "100px"
+      "comment": "100px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-10": {
       "value": "-0.125rem",
-      "comment": "-2px"
+      "comment": "-2px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-20": {
       "value": "-0.25rem",
-      "comment": "-4px"
+      "comment": "-4px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-30": {
       "value": "-0.5rem",
-      "comment": "-8px"
+      "comment": "-8px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-40": {
       "value": "-0.75rem",
-      "comment": "-12px"
+      "comment": "-12px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-50": {
       "value": "-1rem",
-      "comment": "-16px"
+      "comment": "-16px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-60": {
       "value": "-1.25rem",
-      "comment": "-20px"
+      "comment": "-20px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-70": {
       "value": "-1.5rem",
-      "comment": "-24px"
+      "comment": "-24px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-80": {
       "value": "-1.75rem",
-      "comment": "-28px"
+      "comment": "-28px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-90": {
       "value": "-2rem",
-      "comment": "-32px"
+      "comment": "-32px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-100": {
       "value": "-2.25rem",
-      "comment": "-36px"
+      "comment": "-36px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-110": {
       "value": "-2.5rem",
-      "comment": "-40px"
+      "comment": "-40px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-120": {
       "value": "-3rem",
-      "comment": "-48px"
+      "comment": "-48px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-130": {
       "value": "-3.25rem",
-      "comment": "-52px"
+      "comment": "-52px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-140": {
       "value": "-3.5rem",
-      "comment": "-56px"
+      "comment": "-56px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-150": {
       "value": "-3.75rem",
-      "comment": "-60px"
+      "comment": "-60px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-160": {
       "value": "-4.5rem",
-      "comment": "-72px"
+      "comment": "-72px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-170": {
       "value": "-5rem",
-      "comment": "-80px"
+      "comment": "-80px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-180": {
       "value": "-6rem",
-      "comment": "-96px"
+      "comment": "-96px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     },
     "negative-190": {
       "value": "-6.25rem",
-      "comment": "-100px"
+      "comment": "-100px",
+      "deprecated": true,
+      "deprecated_comment": "replace with the \"d\" token"
     }
   }
 }


### PR DESCRIPTION
## Description of the change

- Add space prefix tokens as deprecated
- Change config logic to add @deprecated comment when the token is marked as such

![Screen Shot 2024-08-07 at 13 43 12](https://github.com/user-attachments/assets/853566c6-df1b-4bff-b057-dd8002cb4cab)


## Type of change

- [x] Non-Breaking Change (change to existing functionality)

