### PR TITLE
fix(components): Update menu outline color to gray

### DIFF
--- a/.changeset/odd-planets-visit.md
+++ b/.changeset/odd-planets-visit.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Update menu outline color to gray

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -63,7 +63,7 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
             flexDirection="column"
             maxWidth="280px"
             minWidth="160px"
-            outlineColor="colorBorderweaker"
+            outlineColor="colorBorderWeaker"
             outlineStyle="borderStyleSolid"
             outlineWidth="borderWidth10"
           >

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -63,7 +63,7 @@ const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
             flexDirection="column"
             maxWidth="280px"
             minWidth="160px"
-            outlineColor="colorBorderPrimary"
+            outlineColor="colorBorderweaker"
             outlineStyle="borderStyleSolid"
             outlineWidth="borderWidth10"
           >


### PR DESCRIPTION
## Description of the change

The outline color of the menu is inconsistent with the rest of the border colors we use and e.g. also inconsistent with the current user menu we have in the classic app.

### Current menu outline
![Screenshot_20240904_152315](https://github.com/user-attachments/assets/c498da76-a980-455d-9020-2f6ab2895b0d)

### Old user menu in classic app with HeadlessUI menu
![image](https://github.com/user-attachments/assets/43ddeb80-33fd-4c99-ba22-fe2a3f9db8fd)

When replacing the old headlessUI menu with the Pluto menu the outline makes the borders look different than in all the other places.

### new user menu in classic app with Pluto menu
![image](https://github.com/user-attachments/assets/917ef9a6-2403-4299-a5ae-b3896a3a8b1d)
