### PR TITLE
chore(components): allow box props to be added to Menu

### DIFF
--- a/.changeset/long-carpets-work.md
+++ b/.changeset/long-carpets-work.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+Allow box properties to be passed to menu

--- a/packages/components/src/components/Menu/Menu.stories.tsx
+++ b/packages/components/src/components/Menu/Menu.stories.tsx
@@ -60,7 +60,7 @@ const CustomButtonMenu = (): JSX.Element => {
   const menuButton = <Button variant="primary">Open Menu</Button>;
 
   return (
-    <Box.div minHeight="100px" zIndex="zIndex10">
+    <Box.div minHeight="100px">
       <Menu items={items} menuButton={menuButton} />
     </Box.div>
   );

--- a/packages/components/src/components/Menu/Menu.stories.tsx
+++ b/packages/components/src/components/Menu/Menu.stories.tsx
@@ -60,7 +60,7 @@ const CustomButtonMenu = (): JSX.Element => {
   const menuButton = <Button variant="primary">Open Menu</Button>;
 
   return (
-    <Box.div minHeight="100px">
+    <Box.div minHeight="100px" zIndex="zIndex10">
       <Menu items={items} menuButton={menuButton} />
     </Box.div>
   );

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -20,6 +20,8 @@ export type MenuProps = {
   menuButton?: JSX.Element;
   /** The list of menu items. */
   items: MenuItemProps[];
+  /** The expanded menu z-index. */
+  menuZIndex?: HTMLDivElement["style"]["zIndex"];
 };
 
 const VerticalEllipsisButton = (
@@ -38,7 +40,7 @@ const FullWidthButton = ({ ...props }) => (
 
 /** A menu is a button element that opens a menu with items. */
 const Menu = React.forwardRef<HTMLButtonElement, BoxProps & MenuProps>(
-  ({ menuButton, items, ...props }, ref) => {
+  ({ menuButton, items, menuZIndex = "auto", ...props }, ref) => {
     const store = useMenuStore();
 
     const button = menuButton || VerticalEllipsisButton;
@@ -55,7 +57,7 @@ const Menu = React.forwardRef<HTMLButtonElement, BoxProps & MenuProps>(
           store={store}
         />
 
-        <AriakitMenu store={store}>
+        <AriakitMenu store={store} style={{ zIndex: menuZIndex }}>
           <Box.div
             backgroundColor="colorBackground"
             borderRadius="borderRadius20"

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -7,7 +7,7 @@ import {
 } from "@ariakit/react";
 import map from "lodash/map";
 import { Button } from "../Button";
-import { Box } from "../../primitives/Box";
+import { Box, BoxProps } from "../../primitives/Box";
 
 export type MenuItemProps = {
   label: ReactNode | string;
@@ -37,14 +37,14 @@ const FullWidthButton = ({ ...props }) => (
 );
 
 /** A menu is a button element that opens a menu with items. */
-const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
-  ({ menuButton, items }, ref) => {
+const Menu = React.forwardRef<HTMLButtonElement, BoxProps & MenuProps>(
+  ({ menuButton, items, ...props }, ref) => {
     const store = useMenuStore();
 
     const button = menuButton || VerticalEllipsisButton;
 
     return (
-      <Box.div>
+      <Box.div {...props}>
         <MenuButton
           render={(props) =>
             React.cloneElement(button, {


### PR DESCRIPTION
## Description of the change

- Allow BoxProps to be passed as properties to Menu component
- Add property to change menu z index when opened

example:

```jsx
<Box.div minHeight="100px">
  <Menu items={items} menuButton={menuButton} menuZIndex="10" />
  <Input type="text" />
</Box.div>
```

![Screen Shot 2024-09-11 at 13 59 17](https://github.com/user-attachments/assets/301f714a-c0da-462f-9d06-a5e0dccd1539)


## Type of change

- [x] Non-Breaking Change (change to existing functionality)


