### PR TITLE
fix(components: Remove menu white corners by adding overflow hidden

### DIFF
--- a/.changeset/swift-apes-repeat.md
+++ b/.changeset/swift-apes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": patch
+---
+
+Add overflow hidden to Menu avoiding square corners to be visible

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -68,6 +68,7 @@ const Menu = React.forwardRef<HTMLButtonElement, BoxProps & MenuProps>(
             outlineColor="colorBorderWeaker"
             outlineStyle="borderStyleSolid"
             outlineWidth="borderWidth10"
+            overflow="hidden"
           >
             {map(items, ({ label, onClick, disabled }, i) => (
               <MenuItem key={i}>


### PR DESCRIPTION
## Description of the change

- Add overflow hidden to menu so the square corners of the items are not shown outside of the container

BEFORE

![Screen Shot 2024-09-12 at 10 48 15](https://github.com/user-attachments/assets/7983fff4-b24e-464f-917d-fac0bc5eeef5)

AFTER

![Screen Shot 2024-09-12 at 10 48 02](https://github.com/user-attachments/assets/00cd5da9-e7d4-4f3c-9189-4a6d18b30037)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
