### PR TITLE
feat: update the Heading default color

### DIFF
--- a/.changeset/young-trains-matter.md
+++ b/.changeset/young-trains-matter.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Heading]: Change default color to contentPrimary

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -139,7 +139,7 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
       children,
       marginBottom = "space70",
       size = "heading20",
-      color = "colorTextHeadingStronger",
+      color = "contentPrimary",
       ...props
     },
     ref,


### PR DESCRIPTION
## Description of the change

We realized the need to update all places where the Heading component is used to apply `contentPrimary` as the color. To simplify this, we'll set `contentPrimary` as the default color to avoid making changes in multiple places.

This was agreed with Hanna, but also let me know what you think about it. 

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
