### PR TITLE
fix(docs): change TOKEN_COLUMNS to avoid conflicting tokens with the same name

### DIFF
--- a/.changeset/weak-moons-call.md
+++ b/.changeset/weak-moons-call.md
@@ -1,0 +1,6 @@
+---
+"@localyze-pluto/design-tokens": patch
+"@localyze-pluto/components": patch
+---
+
+Fix storybook pages by avoiding wrong parsed token names and name conflict

--- a/packages/design-tokens/docs/borders.mdx
+++ b/packages/design-tokens/docs/borders.mdx
@@ -11,12 +11,12 @@ import { TokensTable } from "./components/TokensTable";
 
 ## Border Styles
 
-<TokensTable data={borderStyleTokens} />
+<TokensTable data={borderStyleTokens} name="borderStyle" />
 
 ## Border Widths
 
-<TokensTable data={borderWidthTokens} />
+<TokensTable data={borderWidthTokens} name="borderWidth" />
 
 ## Border Radii
 
-<TokensTable data={borderRadiiTokens} />
+<TokensTable data={borderRadiiTokens} name="borderRadius" />

--- a/packages/design-tokens/docs/colors.mdx
+++ b/packages/design-tokens/docs/colors.mdx
@@ -7,4 +7,4 @@ import { TokensTable } from "./components/TokensTable";
 
 <br />
 
-<TokensTable data={colorTokens} />
+<TokensTable data={colorTokens} name="color" />

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -18,15 +18,17 @@ import { TokenName } from "./TokenName";
 
 export const TokensTable = ({
   data,
+  name,
 }: {
   data: Record<string, Record<string, Token>>;
+  name: string;
 }): JSX.Element => {
   const tokenNames: Array<string> = filter(
     keys(data),
     (item) => item !== "default",
   );
   const columnGroups = map(tokenNames, (token) => {
-    return TOKEN_COLUMNS[token];
+    return TOKEN_COLUMNS[name][token];
   });
   const rowGroups: TokenRow[][] = map(columnGroups, (columns, index) => {
     const token = tokenNames[index];

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -53,7 +53,7 @@ export const TokensTable = ({
             return (
               <Tr key={tokenName}>
                 {map(row, (cell, index) => {
-                  const column = columnGroups[0][index].name;
+                  const column = columnGroups[0][index]?.name;
                   return (
                     <Td key={`${tokenName}${column}`}>
                       {index === 0 ? (

--- a/packages/design-tokens/docs/components/TokensTable.tsx
+++ b/packages/design-tokens/docs/components/TokensTable.tsx
@@ -13,22 +13,23 @@ import {
 import { Token } from "../types/Token";
 import { buildTokensTableRows } from "../utils";
 import { TokenRow } from "../types/TokenRow";
+import { Box } from "../../../components/src/primitives/Box";
 import { TOKEN_COLUMNS } from "./constants";
 import { TokenName } from "./TokenName";
 
 export const TokensTable = ({
   data,
-  name,
+  category,
 }: {
   data: Record<string, Record<string, Token>>;
-  name: string;
+  category: string;
 }): JSX.Element => {
   const tokenNames: Array<string> = filter(
     keys(data),
     (item) => item !== "default",
   );
   const columnGroups = map(tokenNames, (token) => {
-    return TOKEN_COLUMNS[name][token];
+    return TOKEN_COLUMNS[category][token];
   });
   const rowGroups: TokenRow[][] = map(columnGroups, (columns, index) => {
     const token = tokenNames[index];
@@ -36,41 +37,43 @@ export const TokensTable = ({
   });
 
   return (
-    <Table style={{ width: "100%" }}>
-      <THead>
-        <Tr>
-          {map(columnGroups[0], (column) => {
-            return (
-              <Th key={column.name}>
-                <h3>{column.name}</h3>
-              </Th>
-            );
-          })}
-        </Tr>
-      </THead>
-      <TBody>
-        {map(rowGroups, (rows) =>
-          map(rows, (row) => {
-            const tokenName = row[0] as string;
-            return (
-              <Tr key={tokenName}>
-                {map(row, (cell, index) => {
-                  const column = columnGroups[0][index]?.name;
-                  return (
-                    <Td key={`${tokenName}${column}`}>
-                      {index === 0 ? (
-                        <TokenName tokenName={cell as string} />
-                      ) : (
-                        cell
-                      )}
-                    </Td>
-                  );
-                })}
-              </Tr>
-            );
-          }),
-        )}
-      </TBody>
-    </Table>
+    <Box.div>
+      <Table style={{ width: "100%" }}>
+        <THead>
+          <Tr>
+            {map(columnGroups[0], (column) => {
+              return (
+                <Th key={column.name}>
+                  <h3>{column.name}</h3>
+                </Th>
+              );
+            })}
+          </Tr>
+        </THead>
+        <TBody>
+          {map(rowGroups, (rows) =>
+            map(rows, (row) => {
+              const tokenName = row[0] as string;
+              return (
+                <Tr key={tokenName}>
+                  {map(row, (cell, index) => {
+                    const column = columnGroups[0][index]?.name;
+                    return (
+                      <Td key={`${tokenName}${column}`}>
+                        {index === 0 ? (
+                          <TokenName tokenName={cell as string} />
+                        ) : (
+                          cell
+                        )}
+                      </Td>
+                    );
+                  })}
+                </Tr>
+              );
+            }),
+          )}
+        </TBody>
+      </Table>
+    </Box.div>
   );
 };

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -105,21 +105,14 @@ const FONT_SIZE = reduce(
         name: "Name",
         transform: getTokenNameFromTuple(prefix),
       },
-      { name: "Pixels", transform: getTokenComment },
+      { name: "Weight", transform: getTokenValue },
       { name: "Rems", transform: getTokenValue },
       {
         name: "Preview",
         transform: createPreview({
-          prefix,
-          attribute: "fontSize",
+          prefix: getTokenKey(fontWeightTokens),
+          attribute: "fontWeight",
           children: TEXT_PREVIEW,
-          componentProps: {
-            p: "space40",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            maxWidth: "600px",
-          },
         }),
       },
     ];
@@ -259,21 +252,6 @@ export const TOKEN_COLUMNS: TokenColumnsProps = {
             w="50px"
           />
         ),
-      }),
-    },
-  ],
-  [getTokenKey(fontWeightTokens)]: [
-    {
-      name: "Name",
-      transform: getTokenName(fontWeightTokens),
-    },
-    { name: "Weight", transform: getTokenValue },
-    {
-      name: "Preview",
-      transform: createPreview({
-        prefix: getTokenKey(fontWeightTokens),
-        attribute: "fontWeight",
-        children: TEXT_PREVIEW,
       }),
     },
   ],

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -107,7 +107,6 @@ const FONT_SIZE = reduce(
         name: "Name",
         transform: getTokenNameFromTuple(prefix),
       },
-      { name: "Weight", transform: getTokenValue },
       { name: "Rems", transform: getTokenValue },
       {
         name: "Preview",

--- a/packages/design-tokens/docs/components/constants.tsx
+++ b/packages/design-tokens/docs/components/constants.tsx
@@ -24,7 +24,7 @@ import {
   hexToRgb,
   hexToHsla,
 } from "../utils";
-import { Box } from "../../../components/src/primitives/Box";
+import { Box, BoxProps } from "../../../components/src/primitives/Box";
 import { Text } from "../../../components/src/primitives/Text";
 import { TokenColumn } from "../types/TokenColumn";
 import { Token } from "../types/Token";
@@ -35,7 +35,9 @@ const TEXT_PREVIEW = (
 );
 
 type TokenColumnsProps = {
-  [key: string]: Array<TokenColumn>;
+  [category: string]: {
+    [key: string]: Array<TokenColumn>;
+  };
 };
 
 const getTokenFromVariable = (tokens: unknown, token: Token): string => {
@@ -110,6 +112,37 @@ const FONT_SIZE = reduce(
       {
         name: "Preview",
         transform: createPreview({
+          prefix,
+          attribute: "fontSize",
+          children: TEXT_PREVIEW,
+          componentProps: {
+            lineHeight: "1" as BoxProps["lineHeight"],
+          },
+        }),
+      },
+    ];
+
+    return {
+      ...acc,
+      [prefix]: columns,
+    };
+  },
+  {},
+);
+
+const FONT_WEIGHT = reduce(
+  filter(keys(fontWeightTokens), (item) => item !== "default"),
+  (acc, prefix) => {
+    const columns = [
+      {
+        name: "Name",
+        transform: getTokenNameFromTuple(prefix),
+      },
+      { name: "Weight", transform: getTokenValue },
+      { name: "Rems", transform: getTokenValue },
+      {
+        name: "Preview",
+        transform: createPreview({
           prefix: getTokenKey(fontWeightTokens),
           attribute: "fontWeight",
           children: TEXT_PREVIEW,
@@ -165,97 +198,106 @@ const SPACE = reduce(
 );
 
 export const TOKEN_COLUMNS: TokenColumnsProps = {
-  [getTokenKey(borderRadiiTokens)]: [
-    {
-      name: "Name",
-      transform: getTokenName(borderRadiiTokens),
-    },
-    { name: "Pixels", transform: getTokenValue },
-    {
-      name: "Preview",
-      transform: createPreview({
-        prefix: getTokenKey(borderRadiiTokens),
-        attribute: "borderRadius",
-        componentProps: {
-          borderStyle: "borderStyleSolid",
-          w: "50px",
-          h: "50px",
-        },
-        overrideProps: {
-          pill: {
-            h: "30px",
+  borderRadius: {
+    [getTokenKey(borderRadiiTokens)]: [
+      {
+        name: "Name",
+        transform: getTokenName(borderRadiiTokens),
+      },
+      { name: "Pixels", transform: getTokenValue },
+      {
+        name: "Preview",
+        transform: createPreview({
+          prefix: getTokenKey(borderRadiiTokens),
+          attribute: "borderRadius",
+          componentProps: {
+            borderStyle: "borderStyleSolid",
+            w: "50px",
+            h: "50px",
           },
-        },
-      }),
-    },
-  ],
-  [getTokenKey(borderWidthTokens)]: [
-    {
-      name: "Name",
-      transform: getTokenName(borderWidthTokens),
-    },
-    { name: "Pixels", transform: getTokenValue },
-    {
-      name: "Preview",
-      transform: createPreview({
-        prefix: getTokenKey(borderWidthTokens),
-        attribute: "borderWidth",
-        componentProps: {
-          borderStyle: "borderStyleSolid",
-          w: "50px",
-          h: "50px",
-        },
-      }),
-    },
-  ],
-  [getTokenKey(borderStyleTokens)]: [
-    {
-      name: "Name",
-      transform: getTokenName(borderStyleTokens),
-    },
-    { name: "Style", transform: getTokenValue },
-    {
-      name: "Preview",
-      transform: createPreview({
-        prefix: getTokenKey(borderStyleTokens),
-        attribute: "borderStyle",
-        componentProps: {
-          w: "50px",
-          h: "50px",
-        },
-      }),
-    },
-  ],
+          overrideProps: {
+            pill: {
+              h: "30px",
+            },
+          },
+        }),
+      },
+    ],
+  },
 
-  [getTokenKey(iconSizeTokens)]: [
-    {
-      name: "Name",
-      transform: getTokenName(iconSizeTokens),
-    },
-    { name: "Pixels", transform: getTokenComment },
-    { name: "Rems", transform: getTokenValue },
-    {
-      name: "Preview",
-      transform: createPreview({
-        prefix: getTokenKey(iconSizeTokens),
-        component: Icon,
-        componentProps: {
-          decorative: true,
-          display: "flex",
-          icon: "book-open",
-        },
-        attribute: "size",
-        children: (
-          <Box.div
-            backgroundColor="colorBackgroundPrimaryWeakest"
-            h="50px"
-            w="50px"
-          />
-        ),
-      }),
-    },
-  ],
-  ...SPACE,
-  ...FONT_SIZE,
-  ...COLORS,
+  borderWidth: {
+    [getTokenKey(borderWidthTokens)]: [
+      {
+        name: "Name",
+        transform: getTokenName(borderWidthTokens),
+      },
+      { name: "Pixels", transform: getTokenValue },
+      {
+        name: "Preview",
+        transform: createPreview({
+          prefix: getTokenKey(borderWidthTokens),
+          attribute: "borderWidth",
+          componentProps: {
+            borderStyle: "borderStyleSolid",
+            w: "50px",
+            h: "50px",
+          },
+        }),
+      },
+    ],
+  },
+  borderStyle: {
+    [getTokenKey(borderStyleTokens)]: [
+      {
+        name: "Name",
+        transform: getTokenName(borderStyleTokens),
+      },
+      { name: "Style", transform: getTokenValue },
+      {
+        name: "Preview",
+        transform: createPreview({
+          prefix: getTokenKey(borderStyleTokens),
+          attribute: "borderStyle",
+          componentProps: {
+            w: "50px",
+            h: "50px",
+          },
+        }),
+      },
+    ],
+  },
+  iconSize: {
+    [getTokenKey(iconSizeTokens)]: [
+      {
+        name: "Name",
+        transform: getTokenName(iconSizeTokens),
+      },
+      { name: "Pixels", transform: getTokenComment },
+      { name: "Rems", transform: getTokenValue },
+      {
+        name: "Preview",
+        transform: createPreview({
+          prefix: getTokenKey(iconSizeTokens),
+          component: Icon,
+          componentProps: {
+            decorative: true,
+            display: "flex",
+            icon: "book-open",
+          },
+          attribute: "size",
+          children: (
+            <Box.div
+              backgroundColor="colorBackgroundPrimaryWeakest"
+              h="50px"
+              w="50px"
+            />
+          ),
+        }),
+      },
+    ],
+  },
+  space: { ...SPACE },
+  fontSize: { ...FONT_SIZE },
+  fontWeight: { ...FONT_WEIGHT },
+  color: { ...COLORS },
 };

--- a/packages/design-tokens/docs/components/createPreview.tsx
+++ b/packages/design-tokens/docs/components/createPreview.tsx
@@ -29,7 +29,7 @@ export const createPreview =
   ([tokenName, token]: TokenTuple): JSX.Element => {
     const tokenProps = overrideProps[token.value];
     const normalizedSuffix = replace(
-      upperFirst(replace(tokenName, "-", "")),
+      upperFirst(replace(camelCase(tokenName), "-", "")),
       "Negative",
       "",
     );

--- a/packages/design-tokens/docs/font-sizes.mdx
+++ b/packages/design-tokens/docs/font-sizes.mdx
@@ -7,4 +7,4 @@ import * as fontSizeTokens from "../src/tokens/font-size.tokens.json";
 
 <br />
 
-<TokensTable data={fontSizeTokens} />
+<TokensTable data={fontSizeTokens} name="fontSize" />

--- a/packages/design-tokens/docs/font-weights.mdx
+++ b/packages/design-tokens/docs/font-weights.mdx
@@ -7,4 +7,4 @@ import * as fontWeightTokens from "../src/tokens/font-weight.tokens.json";
 
 <br />
 
-<TokensTable data={fontWeightTokens} />
+<TokensTable data={fontWeightTokens} name="fontWeight" />

--- a/packages/design-tokens/docs/icon-sizes.mdx
+++ b/packages/design-tokens/docs/icon-sizes.mdx
@@ -7,4 +7,4 @@ import * as iconSizeTokens from "../src/tokens/size.tokens.json";
 
 <br />
 
-<TokensTable data={iconSizeTokens} />
+<TokensTable data={iconSizeTokens} name="iconSize" />

--- a/packages/design-tokens/docs/spacing.mdx
+++ b/packages/design-tokens/docs/spacing.mdx
@@ -7,4 +7,4 @@ import * as spaceTokens from "../src/tokens/space.tokens.json";
 
 <br />
 
-<TokensTable data={spaceTokens} />
+<TokensTable data={spaceTokens} name="space" />

--- a/packages/design-tokens/docs/utils/getTokenNameFromTuple.ts
+++ b/packages/design-tokens/docs/utils/getTokenNameFromTuple.ts
@@ -8,5 +8,5 @@ type TransformFn = (tuple: TokenTuple) => string;
 export const getTokenNameFromTuple =
   (prefix: string): TransformFn =>
   ([tokenName]: TokenTuple) => {
-    return `${camelCase(prefix)}${upperFirst(replace(tokenName, "-", ""))}`;
+    return `${camelCase(prefix)}${upperFirst(replace(camelCase(tokenName), "-", ""))}`;
   };


### PR DESCRIPTION
## Description of the change

- Add a name property to TokensTable
- Add a null check to TokensTable to avoid breaking by accessing an undefined value
- Change TOKENS_TABLE to have one more level (or prefix) to each object. So a titleDisplay that comes from font-size would not collide with titleDisplay that comes from font-weight
- Call camelcase on tokens names avoiding things as `colorBackgrounddecorative-strong` correcting it to `colorBackgroundDecorativeStrong`


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Non-Breaking Change (change to existing functionality)

### BEFORE


![Screen Shot 2024-09-18 at 08 50 40](https://github.com/user-attachments/assets/814b83a8-4489-43f6-8cdd-c99be82690b9)
![Screen Shot 2024-09-18 at 08 50 31](https://github.com/user-attachments/assets/0bb11a0c-126a-4b01-942c-b5721eb33e7b)

### AFTER
![Screen Shot 2024-09-18 at 08 50 22](https://github.com/user-attachments/assets/ac8dfee0-523f-444f-bc82-616db7a73623)
![Screen Shot 2024-09-18 at 08 50 48](https://github.com/user-attachments/assets/7df73aff-5ca7-4555-a029-be822ecfffbc)

