### PR TITLE
feat: Update default color ModalHeading DrawerHeading

### DIFF
--- a/.changeset/quiet-rockets-tap.md
+++ b/.changeset/quiet-rockets-tap.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[ModalHeading, DrawerHeading]: Change default color to contentPrimary

--- a/packages/components/src/components/Drawer/DrawerHeading.tsx
+++ b/packages/components/src/components/Drawer/DrawerHeading.tsx
@@ -13,7 +13,7 @@ const DrawerHeading = React.forwardRef<HTMLHeadingElement, DrawerHeadingProps>(
     return (
       <Heading
         as="h2"
-        color="colorTextHeadingStronger"
+        color="contentPrimary"
         marginBottom="m0"
         ref={ref}
         size="heading50"

--- a/packages/components/src/components/Drawer/DrawerHeading.tsx
+++ b/packages/components/src/components/Drawer/DrawerHeading.tsx
@@ -11,14 +11,7 @@ export interface DrawerHeadingProps
 const DrawerHeading = React.forwardRef<HTMLHeadingElement, DrawerHeadingProps>(
   ({ children, ...props }, ref) => {
     return (
-      <Heading
-        as="h2"
-        color="contentPrimary"
-        marginBottom="m0"
-        ref={ref}
-        size="heading50"
-        {...props}
-      >
+      <Heading as="h2" marginBottom="m0" ref={ref} size="heading50" {...props}>
         {children}
       </Heading>
     );

--- a/packages/components/src/components/Modal/ModalHeading.tsx
+++ b/packages/components/src/components/Modal/ModalHeading.tsx
@@ -13,7 +13,7 @@ const ModalHeading = React.forwardRef<HTMLHeadingElement, ModalHeadingProps>(
     return (
       <Heading
         as="h2"
-        color="colorTextHeadingStronger"
+        color="contentPrimary"
         marginBottom="m0"
         ref={ref}
         size="heading60"

--- a/packages/components/src/components/Modal/ModalHeading.tsx
+++ b/packages/components/src/components/Modal/ModalHeading.tsx
@@ -11,14 +11,7 @@ export interface ModalHeadingProps
 const ModalHeading = React.forwardRef<HTMLHeadingElement, ModalHeadingProps>(
   ({ children, ...props }, ref) => {
     return (
-      <Heading
-        as="h2"
-        color="contentPrimary"
-        marginBottom="m0"
-        ref={ref}
-        size="heading60"
-        {...props}
-      >
+      <Heading as="h2" marginBottom="m0" ref={ref} size="heading60" {...props}>
         {children}
       </Heading>
     );


### PR DESCRIPTION
## Description of the change

After updating the `Heading` default color ( in https://github.com/Localitos/pluto/pull/1731), we realized that there are still headings using the prior color. With this change we should have address all headings and have the same color.

## Type of change
- [x] New feature (non-breaking change that adds functionality)

DrawerHeading
<img width="584" alt="Screenshot 2024-09-26 at 15 06 33" src="https://github.com/user-attachments/assets/49bb1c36-6950-4919-bbd8-db9ddceca9c6">

ModalHeading
<img width="617" alt="Screenshot 2024-09-26 at 15 06 58" src="https://github.com/user-attachments/assets/2db1bf8d-8d0e-42ae-80fa-a8439d68a6af">



