### PR TITLE
fix: set sameWidth from Select as default true

### DIFF
--- a/.changeset/four-games-nail.md
+++ b/.changeset/four-games-nail.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[Select]: Fix: set sameWidth prop as default as we used before

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -65,7 +65,7 @@ export const Default = (): JSX.Element => {
   );
 };
 
-export const SameWidth = (): JSX.Element => {
+export const SameWidthAsFalse = (): JSX.Element => {
   const selectID = useUID();
   const helpTextID = useUID();
   return (
@@ -76,7 +76,8 @@ export const SameWidth = (): JSX.Element => {
         id={selectID}
         items={selectItems}
         name="select"
-        sameWidth
+        popoverWidth="150px"
+        sameWidth={false}
       />
       <HelpText id={helpTextID}>Please choose one of the values.</HelpText>
     </Box.form>

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -146,7 +146,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       setValue,
       size = "small",
       value,
-      sameWidth,
+      sameWidth = true,
       popoverWidth,
       popoverMaxWidth,
       ...props


### PR DESCRIPTION
## Description of the change

When exposing the `sameWidth` property, we forgot to set its default value to true, as all usage of Select component was already configured to use it that way.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
