### PR TITLE
feat: update ContentCard component

### DIFF
--- a/.changeset/cold-news-glow.md
+++ b/.changeset/cold-news-glow.md
@@ -1,0 +1,14 @@
+---
+"@localyze-pluto/components": major
+---
+
+[ContentCard]
+
+> Breaking change: `iconUrl` prop is now `topLeftElement` and accepts a ReactNode
+
+Minor changes:
+
+- Set Icon wrapper border radius to 8px (shows now like a square)
+- Added new `topRightElement` prop to allow add element in the top right corner of the card
+- Added new `lowOpacity` prop to set the opacity of the card content without include the `topRightElement`
+- Fixed styles: heading color, card content

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import React from "react";
 import { Box } from "../../primitives/Box";
 import { Button } from "../Button";
+import { Badge } from "../Badge";
 import { ContentCard, InteractiveElementType } from "./ContentCard";
 
 export default {
@@ -87,16 +88,48 @@ CustomCta.args = {
   interactiveElementType: InteractiveElementType.Custom,
 };
 
-export const WithIcon: Story = Template.bind({});
-WithIcon.args = {
+export const WithTopLeftElement: Story = Template.bind({});
+WithTopLeftElement.args = {
   ...defaultProps,
-  iconUrl: "/images/house.png",
+  imagePosition: "top",
+  topLeftElement: (
+    <Box.img aria-hidden h="auto" src="/images/house.png" w="100%" />
+  ),
 };
 
 export const PortraitImage: Story = Template.bind({});
 PortraitImage.args = {
   ...defaultProps,
   imageSrc: "/images/beach-porto-rico.jpg",
+};
+
+export const WithTopRightElement: Story = Template.bind({});
+WithTopRightElement.args = {
+  ...defaultProps,
+  imagePosition: "top",
+  topLeftElement: (
+    <Box.img aria-hidden h="auto" src="/images/house.png" w="100%" />
+  ),
+  topRightElement: (
+    <Box.div position="absolute" right={24} top={24}>
+      <Badge icon="star">Preferred partner</Badge>
+    </Box.div>
+  ),
+};
+
+export const WithLowOpacity: Story = Template.bind({});
+WithLowOpacity.args = {
+  ...defaultProps,
+  imagePosition: "top",
+  topLeftElement: (
+    <Box.img aria-hidden h="auto" src="/images/house.png" w="100%" />
+  ),
+  hasLowOpacity: true,
+  topRightElement: (
+    <Box.div position="absolute" right={24} top={24}>
+      <Badge color="red">Disabled</Badge>
+    </Box.div>
+  ),
 };
 
 export const InList = (): JSX.Element => {

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -32,8 +32,6 @@ export type ContentCardProps = {
   date?: string;
   /** Sets the image position on the card */
   imagePosition?: ImagePosition;
-  /** Sets an icon to be rendered over the image */
-  iconUrl?: string;
   /** Sets the background color according with the type */
   background?: Background;
   /** Sets the type of the clickable element */
@@ -50,6 +48,16 @@ export type ContentCardProps = {
   as?: React.ComponentProps<typeof Box.div>["as"];
   /** Overwrites default maxWidth */
   maxWidth?: BoxProps["maxW"];
+  /** Overwrites default h (height) */
+  h?: BoxProps["h"];
+  /** Overwrites default w (width) */
+  w?: BoxProps["w"];
+  /** Element to be rendered on the top left corner of the card */
+  topLeftElement?: ReactNode;
+  /** Element to be rendered on the top right corner of the card */
+  topRightElement?: ReactNode;
+  /** Applies reduced opacity to the card */
+  hasLowOpacity?: boolean;
 };
 
 const backgroundColor: Record<Background, BoxProps["backgroundColor"]> = {
@@ -69,12 +77,16 @@ export const ContentCard = ({
   text,
   tag,
   date,
-  iconUrl,
+  topLeftElement,
   imagePosition = "right",
   background = "default",
   target,
   as = "div",
   maxWidth,
+  h,
+  w,
+  topRightElement,
+  hasLowOpacity,
 }: ContentCardProps): JSX.Element => {
   const isImageOnTop = imagePosition === "top";
 
@@ -114,144 +126,168 @@ export const ContentCard = ({
 
   return (
     <Box.div
-      as={isCardInteractive ? "a" : as}
-      backgroundColor={backgroundColor[background]}
       border={0}
-      borderRadius={"borderRadius40"}
+      borderRadius="borderRadius40"
       boxShadow={
-        isCardInteractive && {
-          _: "none",
-          hover: "shadowStrong",
-        }
+        isCardInteractive
+          ? {
+              _: "none",
+              hover: "shadowStrong",
+            }
+          : "none"
       }
-      display="flex"
-      flexDirection={
-        isImageOnTop ? "column-reverse" : { _: "column-reverse", md: "unset" }
-      }
-      fontFamily="fontFamilyNotoSans"
-      justifyContent="space-between"
       maxH={maxHeight[imagePosition]}
       maxW={maxWidth || maxWidthDefault[imagePosition]}
-      padding="d0"
-      textDecoration="none"
-      {...(isCardInteractive ? interactiveElementProps : {})}
+      overflow="hidden"
+      position="relative"
     >
       <Box.div
-        borderRadius="borderRadius40 borderRadius0 borderRadius0 borderRadius40"
-        lineHeight="lineHeight30"
-        maxWidth={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}
-        padding="d6"
+        as={isCardInteractive ? "a" : as}
+        backgroundColor={backgroundColor[background]}
+        display="flex"
+        flexDirection={
+          isImageOnTop ? "column-reverse" : { _: "column-reverse", md: "unset" }
+        }
+        fontFamily="fontFamilyNotoSans"
+        h={h}
+        justifyContent="start"
+        maxH={maxHeight[imagePosition]}
+        maxW={maxWidth || maxWidthDefault[imagePosition]}
+        opacity={hasLowOpacity ? 0.6 : 1}
+        textDecoration="none"
+        w={w}
+        {...(isCardInteractive ? interactiveElementProps : {})}
       >
-        <Text.div
-          color="colorTextHeadingStronger"
-          fontSize="fontSize10"
-          lineHeight="lineHeight10"
-          marginBottom="d1_5"
-        >
-          {tag}
-        </Text.div>
-        <Heading marginBottom="m0" size="heading60">
-          {title}
-        </Heading>
-        <Text.p
-          color="colorTextStrongest"
-          fontSize="fontSize20"
-          marginBottom="d6"
-          marginTop="d2"
-        >
-          {text}
-        </Text.p>
-        {date && (
-          <Box.div
-            alignItems="center"
-            color="colorTextLinkStrong"
-            display="flex"
-            fontSize="fontSize20"
-            fontWeight="fontWeightMedium"
-            gap="d2"
-            marginBottom="d6"
-          >
-            <Icon decorative icon="calendar" size="sizeIcon30" />
-            <Text.span
-              fontFamily="fontFamilyNotoSans"
-              fontSize="fontSize20"
-              lineHeight="lineHeight30"
-            >
-              {date}
-            </Text.span>
-          </Box.div>
-        )}
         <Box.div
-          alignItems={
-            isImageOnTop ? "center" : { _: "flex-start", md: "center" }
-          }
-          display="flex"
-          flexDirection={isImageOnTop ? "row" : { _: "column", md: "row" }}
-          flexShrink={2}
-          gap="d4"
+          borderRadius="borderRadius40 borderRadius0 borderRadius0 borderRadius40"
+          lineHeight="lineHeight30"
+          maxWidth={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}
+          padding="d6"
         >
-          {InteractiveElementType.Button === interactiveElementType && (
-            <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
-              <Button
-                as="a"
-                fullWidth
-                variant="secondary"
-                {...interactiveElementProps}
+          {tag && (
+            <Text.div
+              color="colorTextHeadingStronger"
+              fontSize="fontSize10"
+              lineHeight="lineHeight10"
+              marginBottom="d2"
+            >
+              {tag}
+            </Text.div>
+          )}
+          <Heading
+            color="cardContentTitle"
+            marginBottom="m0"
+            size="title-group"
+          >
+            {title}
+          </Heading>
+          <Text.p
+            color="cardContentBody"
+            fontSize="fontSize20"
+            marginBottom="d6"
+            marginTop="d2"
+          >
+            {text}
+          </Text.p>
+          {date && (
+            <Box.div
+              alignItems="center"
+              color="colorTextLinkStrong"
+              display="flex"
+              fontSize="fontSize20"
+              fontWeight="fontWeightMedium"
+              gap="d2"
+              marginBottom="d6"
+            >
+              <Icon decorative icon="calendar" size="sizeIcon30" />
+              <Text.span
+                fontFamily="fontFamilyNotoSans"
+                fontSize="fontSize20"
+                lineHeight="lineHeight30"
               >
+                {date}
+              </Text.span>
+            </Box.div>
+          )}
+          <Box.div
+            alignItems={
+              isImageOnTop ? "center" : { _: "flex-start", md: "center" }
+            }
+            display="flex"
+            flexDirection={isImageOnTop ? "row" : { _: "column", md: "row" }}
+            flexShrink={2}
+            gap="d4"
+          >
+            {InteractiveElementType.Button === interactiveElementType && (
+              <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
+                <Button
+                  as="a"
+                  fullWidth
+                  variant="secondary"
+                  {...interactiveElementProps}
+                >
+                  {callToAction}
+                </Button>
+              </Box.div>
+            )}
+
+            {InteractiveElementType.Anchor === interactiveElementType && (
+              <Anchor {...interactiveElementProps}>{callToAction || ""}</Anchor>
+            )}
+
+            {InteractiveElementType.Custom === interactiveElementType && (
+              <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
                 {callToAction}
-              </Button>
+              </Box.div>
+            )}
+          </Box.div>
+        </Box.div>
+        <Box.div
+          alignItems="center"
+          borderRadius={imageBorderRadius[imagePosition]}
+          display="flex"
+          maxH={isImageOnTop ? 180 : { _: 180, md: "unset" }}
+          overflow="hidden"
+          position="relative"
+          w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}
+        >
+          {topLeftElement && (
+            <Box.div
+              alignItems="center"
+              backgroundColor="colorBackground"
+              borderRadius="borderRadius30"
+              data-testid="service-content-card-icon"
+              display="flex"
+              gap="d2"
+              h={56}
+              justifyContent="center"
+              left="24px"
+              padding="d2"
+              position="absolute"
+              top="24px"
+              w={56}
+            >
+              <Box.div
+                alignItems="center"
+                display="flex"
+                justifyContent="center"
+                position="relative"
+              >
+                {topLeftElement}
+              </Box.div>
             </Box.div>
           )}
 
-          {InteractiveElementType.Anchor === interactiveElementType && (
-            <Anchor {...interactiveElementProps}>{callToAction || ""}</Anchor>
-          )}
-
-          {InteractiveElementType.Custom === interactiveElementType && (
-            <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
-              {callToAction}
-            </Box.div>
-          )}
+          <Box.img
+            alt={imageAlt}
+            h="100%"
+            objectFit="cover"
+            src={imageSrc}
+            w="100%"
+          />
         </Box.div>
       </Box.div>
-      <Box.div
-        alignItems="center"
-        borderRadius={imageBorderRadius[imagePosition]}
-        display="flex"
-        maxH={isImageOnTop ? 180 : { _: 180, md: "unset" }}
-        overflow="hidden"
-        position="relative"
-        w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}
-      >
-        {iconUrl && (
-          <Box.div
-            alignItems="center"
-            backgroundColor="colorBackground"
-            borderRadius="borderRadiusCircle"
-            data-testid="service-content-card-icon"
-            display="flex"
-            gap="d2"
-            h={56}
-            justifyContent="center"
-            left="16px"
-            position={"absolute"}
-            top={16}
-            w={56}
-          >
-            <Box.div h={24} position="relative" w={24}>
-              <Box.img aria-hidden h="auto" src={iconUrl} w="100%" />
-            </Box.div>
-          </Box.div>
-        )}
-
-        <Box.img
-          alt={imageAlt}
-          h="100%"
-          objectFit="cover"
-          src={imageSrc}
-          w="100%"
-        />
-      </Box.div>
+      {topRightElement}
     </Box.div>
   );
 };


### PR DESCRIPTION
## Description of the change

This PR:
* has a breaking change because it changes the `iconUrl` prop to `topLeftElement` since it will accept ReactNode instead of only string. This allows us to use different image components, like Image from nextjs or other type of elements
* adds a new `topRightElement` prop so we allow adding an element in the top right corner of the card
* adds a new `lowOpacity` prop to set the opacity of the card content without including the `topRightElement`
* fixes some style inconsistencies (heading, card content) between the component in Figma and the one from Pluto
* adds `h` and `w` properties to allow setting custom width and height for the card

Disclaimer: we don't have any usage of the `iconUrl`, but I decided to make it a breaking change because of semantics.

## Same screenshots of the changes

<img src="https://github.com/user-attachments/assets/1a6c0738-2bd4-4d22-a6db-6917166e9f7d" alt="" width="50%" height="auto">
<img src="https://github.com/user-attachments/assets/bf16b667-764e-487a-9539-b1db35ce5f88" alt="" width="50%" height="auto">
<img src="https://github.com/user-attachments/assets/cf8474ca-8d5c-464c-a48e-f513903ca83b" alt="" width="50%" height="auto">


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
