### PR TITLE
fix: update content height to fill available space

### DIFF
--- a/.changeset/ninety-bikes-reply.md
+++ b/.changeset/ninety-bikes-reply.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/components": patch
+---
+
+[ContentCard]:
+
+- Fixed an issue where the component didn’t fill all available space, causing cards to look misaligned and out of line when used in a grid

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -132,7 +132,7 @@ WithLowOpacity.args = {
   ),
 };
 
-export const InList = (): JSX.Element => {
+export const InListWithImageOnTop = (): JSX.Element => {
   return (
     <Box.ul
       display="grid"
@@ -141,13 +141,23 @@ export const InList = (): JSX.Element => {
       listStyleType="none"
     >
       <Box.li>
-        <Template {...defaultProps} />
+        <Template
+          {...defaultProps}
+          callToAction="Click here"
+          imagePosition="top"
+          interactiveElementType={InteractiveElementType.Button}
+          text="Small text"
+        />
       </Box.li>
       <Box.li>
-        <Template {...defaultProps} />
+        <Template {...defaultProps} imagePosition="top" tag="" />
       </Box.li>
       <Box.li>
-        <Template {...defaultProps} imageSrc={"/images/beach-porto-rico.jpg"} />
+        <Template
+          {...defaultProps}
+          imagePosition="top"
+          imageSrc={"/images/beach-porto-rico.jpg"}
+        />
       </Box.li>
     </Box.ul>
   );

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -136,6 +136,7 @@ export const ContentCard = ({
             }
           : "none"
       }
+      h="100%"
       maxH={maxHeight[imagePosition]}
       maxW={maxWidth || maxWidthDefault[imagePosition]}
       overflow="hidden"
@@ -149,7 +150,7 @@ export const ContentCard = ({
           isImageOnTop ? "column-reverse" : { _: "column-reverse", md: "unset" }
         }
         fontFamily="fontFamilyNotoSans"
-        h={h}
+        h={h ?? "100%"}
         justifyContent="start"
         maxH={maxHeight[imagePosition]}
         maxW={maxWidth || maxWidthDefault[imagePosition]}
@@ -160,55 +161,59 @@ export const ContentCard = ({
       >
         <Box.div
           borderRadius="borderRadius40 borderRadius0 borderRadius0 borderRadius40"
-          lineHeight="lineHeight30"
+          display="flex"
+          flexDirection="column"
+          flexGrow={1}
           maxWidth={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}
           padding="d6"
         >
-          {tag && (
-            <Text.div
-              color="colorTextHeadingStronger"
-              fontSize="fontSize10"
-              lineHeight="lineHeight10"
-              marginBottom="d2"
-            >
-              {tag}
-            </Text.div>
-          )}
-          <Heading
-            color="cardContentTitle"
-            marginBottom="m0"
-            size="title-group"
-          >
-            {title}
-          </Heading>
-          <Text.p
-            color="cardContentBody"
-            fontSize="fontSize20"
-            marginBottom="d6"
-            marginTop="d2"
-          >
-            {text}
-          </Text.p>
-          {date && (
-            <Box.div
-              alignItems="center"
-              color="colorTextLinkStrong"
-              display="flex"
-              fontSize="fontSize20"
-              fontWeight="fontWeightMedium"
-              gap="d2"
-              marginBottom="d6"
-            >
-              <Icon decorative icon="calendar" size="sizeIcon30" />
-              <Text.span
-                fontFamily="fontFamilyNotoSans"
-                fontSize="fontSize20"
-                lineHeight="lineHeight30"
+          <Box.div lineHeight="lineHeight30">
+            {tag && (
+              <Text.div
+                color="colorTextHeadingStronger"
+                fontSize="fontSize10"
+                lineHeight="lineHeight10"
+                marginBottom="d2"
               >
-                {date}
-              </Text.span>
-            </Box.div>
-          )}
+                {tag}
+              </Text.div>
+            )}
+            <Heading
+              color="cardContentTitle"
+              marginBottom="m0"
+              size="title-group"
+            >
+              {title}
+            </Heading>
+            <Text.p
+              color="cardContentBody"
+              fontSize="fontSize20"
+              marginBottom="d6"
+              marginTop="d2"
+            >
+              {text}
+            </Text.p>
+            {date && (
+              <Box.div
+                alignItems="center"
+                color="colorTextLinkStrong"
+                display="flex"
+                fontSize="fontSize20"
+                fontWeight="fontWeightMedium"
+                gap="d2"
+                marginBottom="d6"
+              >
+                <Icon decorative icon="calendar" size="sizeIcon30" />
+                <Text.span
+                  fontFamily="fontFamilyNotoSans"
+                  fontSize="fontSize20"
+                  lineHeight="lineHeight30"
+                >
+                  {date}
+                </Text.span>
+              </Box.div>
+            )}
+          </Box.div>
           <Box.div
             alignItems={
               isImageOnTop ? "center" : { _: "flex-start", md: "center" }
@@ -217,6 +222,7 @@ export const ContentCard = ({
             flexDirection={isImageOnTop ? "row" : { _: "column", md: "row" }}
             flexShrink={2}
             gap="d4"
+            style={{ marginTop: "auto" }}
           >
             {InteractiveElementType.Button === interactiveElementType && (
               <Box.div w={isImageOnTop ? "100%" : { _: "100%", md: "50%" }}>
@@ -277,7 +283,6 @@ export const ContentCard = ({
               </Box.div>
             </Box.div>
           )}
-
           <Box.img
             alt={imageAlt}
             h="100%"


### PR DESCRIPTION
## Description of the change

#### #TLDR
* Updates the ContentCard's content height to fill all the available space
* Moved the button to the bottom of the content area for better and consistent placement
* Changed the `InList` story to `InListWithImageOnTop` so it's better to see how the cards look like inside a grid

Explanation:
While updating the latest version of Pluto in the classic app, I saw that the cards in the Integrations list were not aligned correctly because the text in one card was smaller than the others. Even after fixing the content height to use all the space, the cards still didn’t align correctly when there was a button. To fix this, I decided to move the button to the bottom.

Bug:
<img width="889" alt="image" src="https://github.com/user-attachments/assets/d4f8ef27-2ac9-4dbe-8412-8faacbc000ca">

Fix:

<img width="890" alt="image" src="https://github.com/user-attachments/assets/db6d5ef7-c6f5-48bc-a2ec-a84352deefc2">


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
