### PR TITLE
fix: improve usability of Tabs component

### DIFF
--- a/.changeset/weak-impalas-travel.md
+++ b/.changeset/weak-impalas-travel.md
@@ -1,0 +1,15 @@
+---
+"@localyze-pluto/components": major
+---
+
+[Tabs]:
+
+> Breaking changes:
+>
+> - Removed the `flexed` prop from the Tabs component, as it is now the default behavior.
+> - Removed the `variant` prop from the Tabs component since it wasn't used in the component.
+
+- Minor changes:
+  - The `TabsList` component now accepts a `fullWidth` prop allowing the tabs list to expand to the full width.
+  - Fixed a bug with the focus indicator, switching from focus to focus-visible for better accessibility.
+  - Fixed styles of the Tabs to be more consistent with Figma

--- a/packages/components/src/components/Tabs/Tab.tsx
+++ b/packages/components/src/components/Tabs/Tab.tsx
@@ -24,18 +24,21 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
         borderBottomColor={{
           _: "transparent",
           disabled: "transparent",
-          hover: "colorBorderWeaker",
-          selected: "colorBorderPrimary",
+          hover: "tabBorderHover",
+          selected: "tabLabelActive",
         }}
         borderBottomStyle="borderStyleSolid"
         borderBottomWidth="borderWidth20"
+        boxShadow={{
+          focusVisible: "shadowFocus",
+        }}
         // There's a conflict with TabPrimitiveProps from Ariakit. We have to convert color to string here because Ariakit doesn't like our responsive/state-based colors.
         color={
           {
-            _: "colorTextStronger",
+            _: "tabLabelDefault",
             disabled: "colorText",
-            hover: "colorTextStrongest",
-            selected: "colorTextLink",
+            hover: "tabLabelHover",
+            selected: "tabBorderActive",
           } as unknown as string
         }
         cursor={{
@@ -46,18 +49,14 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
         disabled={disabled}
         flexGrow={1}
         fontFamily="fontFamilyNotoSans"
-        fontSize="fontSize30"
+        fontSize="fontSize20"
         fontWeight="fontWeightMedium"
         lineHeight="lineHeight30"
-        outlineColor={{ focus: "colorBorderPrimary" }}
-        outlineOffset={{ focus: "borderWidth20" }}
-        outlineStyle={{ focus: "borderStyleSolid" }}
-        outlineWidth={{ focus: "borderWidth20" }}
-        paddingBottom="d1"
-        paddingLeft="d3"
-        paddingRight="d3"
-        paddingTop="d1"
+        outline={{ focus: "none" }}
+        paddingBottom="d2"
+        paddingTop="d0"
         position="relative"
+        px="d1"
         textDecoration="none"
         zIndex="zIndex10"
         {...props}

--- a/packages/components/src/components/Tabs/TabList.tsx
+++ b/packages/components/src/components/Tabs/TabList.tsx
@@ -13,33 +13,37 @@ export interface TabListProps
   children: NonNullable<React.ReactNode>;
   /** Add a divider element on the bottom of the tabs list */
   withDivider?: boolean;
+  /** Extends the tab list to fill the available space. */
+  fullWith?: boolean;
 }
 
 const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
-  ({ children, withDivider, ...props }, ref) => {
+  ({ children, withDivider, fullWith, ...props }, ref) => {
     const tab = React.useContext(TabsContext);
 
     return (
-      <Box.div
-        as={TabListPrimitive}
-        display={tab.variant === "fitted" ? "flex" : "block"}
-        position="relative"
-        store={tab}
-        {...props}
-        ref={ref}
-      >
-        {children}
+      <>
+        <Box.div
+          alignSelf={fullWith ? undefined : "flex-start"}
+          as={TabListPrimitive}
+          display="flex"
+          gap="d6"
+          position="relative"
+          store={tab}
+          {...props}
+          ref={ref}
+        >
+          {children}
+        </Box.div>
         {withDivider && (
           <Box.div
             backgroundColor="colorBorderWeaker"
-            bottom="0"
             h="1px"
-            position="absolute"
             w="100%"
             zIndex="zIndex0"
           />
         )}
-      </Box.div>
+      </>
     );
   },
 );

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -198,39 +198,59 @@ export const ReallyLongTab = (): React.JSX.Element => {
   );
 };
 
-export const Fitted = (): React.JSX.Element => {
+const Tab1 = () => (
+  <Box.div
+    borderColor="colorBorderWeaker"
+    borderStyle="borderStyleSolid"
+    borderWidth="borderWidth10"
+    h="100%"
+    padding="d5"
+    w="100%"
+  >
+    Tab1
+  </Box.div>
+);
+
+const Tab2 = () => (
+  <Box.div
+    borderColor="colorBorderWeaker"
+    borderStyle="borderStyleSolid"
+    borderWidth="borderWidth10"
+    padding="d5"
+  >
+    Tab2
+  </Box.div>
+);
+
+export const FullWidth = (): React.JSX.Element => {
+  const [selectedTab, setSelectedTab] = React.useState("tab1");
+
   return (
-    <Tabs variant="fitted">
-      <TabList aria-label="Page tabs">
-        <Tab>Tab One</Tab>
-        <Tab>Tab Two</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>
-          <Box.div padding="d5">
-            <Heading as="h2" marginBottom="m0" size="heading50">
-              Tab One
-            </Heading>
-            <Paragraph>
-              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
-              sodales vel purus.
-            </Paragraph>
-          </Box.div>
-        </TabPanel>
-        <TabPanel>
-          <Box.div padding="d5">
-            <Heading as="h2" marginBottom="m0" size="heading50">
-              Tab Two
-            </Heading>
-            <Paragraph>
-              Lorem ipsum dolor sit, consectetur. Aliquam ac a. Ligula at et,
-              sodales vel purus.
-            </Paragraph>
-          </Box.div>
-        </TabPanel>
-      </TabPanels>
-    </Tabs>
+    <Box.div display="flex" h="200px">
+      <Tabs>
+        <TabList aria-label="Page tabs" fullWith withDivider>
+          <Tab id="tab1" onClick={() => setSelectedTab("tab1")}>
+            Tab1
+          </Tab>
+          <Tab id="tab2" onClick={() => setSelectedTab("tab2")}>
+            Tab2
+          </Tab>
+        </TabList>
+        <Box.div display="flex" flexDirection="column" flexGrow="1" w="100%">
+          {selectedTab === "tab1" ? <Tab1 /> : <Tab2 />}
+        </Box.div>
+      </Tabs>
+    </Box.div>
   );
+};
+
+FullWidth.parameters = {
+  docs: {
+    description: {
+      story:
+        "You can make the tabs take up the full width by adding the fullWidth property to the TabList component. This helps make the tabs look better on mobile screens, for example.",
+    },
+  },
 };
 
 export const WithDivider = (): React.JSX.Element => {
@@ -273,61 +293,6 @@ WithDivider.parameters = {
     description: {
       story:
         "You can display a divider between the tabs and the content by using the `withDivider` property on the `TabList` component.",
-    },
-  },
-};
-
-const Tab1 = () => (
-  <Box.div
-    borderColor="colorBorderWeaker"
-    borderStyle="borderStyleSolid"
-    borderWidth="borderWidth10"
-    h="100%"
-    padding="d5"
-    w="100%"
-  >
-    Tab1
-  </Box.div>
-);
-
-const Tab2 = () => (
-  <Box.div
-    borderColor="colorBorderWeaker"
-    borderStyle="borderStyleSolid"
-    borderWidth="borderWidth10"
-    padding="d5"
-  >
-    Tab2
-  </Box.div>
-);
-
-export const Flexed = (): React.JSX.Element => {
-  const [selectedTab, setSelectedTab] = React.useState("tab1");
-
-  return (
-    <Box.div display="flex" h="500px">
-      <Tabs flexed>
-        <TabList aria-label="Page tabs" withDivider>
-          <Tab id="tab1" onClick={() => setSelectedTab("tab1")}>
-            Tab1
-          </Tab>
-          <Tab id="tab2" onClick={() => setSelectedTab("tab2")}>
-            Tab2
-          </Tab>
-        </TabList>
-        <Box.div display="flex" flexDirection="column" flexGrow="1">
-          {selectedTab === "tab1" ? <Tab1 /> : <Tab2 />}
-        </Box.div>
-      </Tabs>
-    </Box.div>
-  );
-};
-
-Flexed.parameters = {
-  docs: {
-    description: {
-      story:
-        "This uses {display: flex; flex-direction: column; flex-grow: 1;} for the div wrapping the tabs, to be able to fill the whole remaining container height with one of the containing divs.",
     },
   },
 };

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -3,38 +3,28 @@ import { useTabStore as useTabPrimitiveState } from "@ariakit/react/tab";
 import PropTypes from "prop-types";
 import { Box } from "../../primitives/Box";
 import { TabsContext } from "./TabsContext";
-import type { TabsVariants } from "./types";
 
 export interface TabsProps {
   /** Tells the Tabs which panel to load when it mounts. */
   initialTabId?: string;
-  /** Changes the Tabs' to either fit the width of the containing element or not. */
-  variant?: TabsVariants;
-  /** Use flex column, growing to 1 for the div wrapping the tabs. */
-  flexed?: boolean;
   /** The child elements. */
   children: NonNullable<React.ReactNode>;
 }
 
 /** Tabs are labeled controls that allow users to switch between multiple views within a page */
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
-  ({ children, initialTabId, variant, flexed }, ref) => {
+  ({ children, initialTabId }, ref) => {
     const tab = useTabPrimitiveState({
       defaultSelectedId: initialTabId,
     });
 
-    const value = React.useMemo(() => ({ ...tab, variant }), [tab, variant]);
+    const value = React.useMemo(() => ({ ...tab }), [tab]);
     const returnValue = (
       <TabsContext.Provider value={value}>{children}</TabsContext.Provider>
     );
 
     return (
-      <Box.div
-        display={flexed ? "flex" : "block"}
-        flexDirection={flexed ? "column" : undefined}
-        flexGrow={flexed ? "1" : undefined}
-        ref={ref}
-      >
+      <Box.div display="flex" flexDirection="column" flexGrow={1} ref={ref}>
         {returnValue}
       </Box.div>
     );
@@ -45,7 +35,6 @@ Tabs.displayName = "Tabs";
 
 Tabs.propTypes = {
   initialTabId: PropTypes.string,
-  variant: PropTypes.oneOf(["fitted"]),
   children: PropTypes.node.isRequired,
 };
 

--- a/packages/components/src/components/Tabs/TabsContext.tsx
+++ b/packages/components/src/components/Tabs/TabsContext.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import type { TabStore as TabStorePrimitiveProps } from "@ariakit/react/tab";
-import type { TabsVariants } from "./types";
 
 export interface TabStoreProps extends TabStorePrimitiveProps {
   /** Tells the Tabs which panel to load when it mounts. */
   initialTabId?: string;
-  /** Changes the Tabs' to either fit the width of the containing element or not. */
-  variant?: TabsVariants;
 }
 
 const TabsContext = React.createContext<TabStoreProps>({} as TabStoreProps);

--- a/packages/components/src/components/Tabs/index.ts
+++ b/packages/components/src/components/Tabs/index.ts
@@ -4,4 +4,3 @@ export * from "./TabList";
 export * from "./TabPanels";
 export * from "./TabPanel";
 export * from "./Tab";
-export * from "./types";

--- a/packages/components/src/components/Tabs/types.ts
+++ b/packages/components/src/components/Tabs/types.ts
@@ -1,1 +1,0 @@
-export type TabsVariants = "fitted" | undefined;


### PR DESCRIPTION
## Description of the change

Breaking changes:

* Removed the `flexed` prop from the Tabs component, as it is now the default behavior.
* Removed the `variant` prop from the Tabs component since it wasn't used in the component.

Minor changes:
  - The `TabsList` component now accepts a `fullWidth` prop allowing the tabs list to expand to the full width.
  - Fixed a bug with the focus indicator, switching from focus to focus-visible for better accessibility.
  - Fixed styles of the Tabs to be more consistent with Figma

The bug with the focus:
![ezgif-2-6ff542ae6b](https://github.com/user-attachments/assets/03a7f14f-d43d-457f-84ec-51ed34453266)

With the fix:
![withfix](https://github.com/user-attachments/assets/7c4a3c9e-e8fc-479b-8d8e-840dc3d352c0)



## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
