### PR TITLE
Update utility card to use emoji instead of image

### DIFF
--- a/.changeset/new-rivers-hide.md
+++ b/.changeset/new-rivers-hide.md
@@ -1,0 +1,5 @@
+---
+"@localyze-pluto/components": major
+---
+
+Update UtilityCard to display string-emoji instead of image

--- a/packages/components/src/components/UtilityCard/UtilityCard.stories.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.stories.tsx
@@ -18,8 +18,7 @@ const onClick = (): void =>
   alert("This is what happens when you click on the card");
 
 const defaultProps = {
-  imageAlt: "a beach",
-  imageSrc: "/images/beach-seal-rocks.jpg",
+  emoji: "❤️",
   title: "The card title",
   categoryTag: "The category tag",
   serviceTag: "Concierge Services",
@@ -58,7 +57,7 @@ export const InList = (): JSX.Element => {
         <Template {...defaultProps} />
       </Box.li>
       <Box.li>
-        <Template {...defaultProps} imageSrc={"/images/beach-porto-rico.jpg"} />
+        <Template {...defaultProps} emoji={"🙈"} />
       </Box.li>
     </Box.ul>
   );

--- a/packages/components/src/components/UtilityCard/UtilityCard.test.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.test.tsx
@@ -10,7 +10,7 @@ import {
 const onClick = jest.fn();
 
 const defaultMockProps = {
-  imageSrc: "path-to-image.jpg",
+  emoji: "📦",
   categoryTag: "a service tag",
   title: "Good title!",
 };
@@ -56,13 +56,10 @@ describe("<UtilityCard>", () => {
       expect(screen.queryByText("In progress")).not.toBeInTheDocument();
     });
 
-    it("renders an image", () => {
+    it("renders an emoji", () => {
       renderDefaultCard();
 
-      expect(screen.getByAltText("")).toHaveAttribute(
-        "src",
-        "path-to-image.jpg",
-      );
+      expect(screen.getByText("📦")).toBeVisible();
     });
   });
 

--- a/packages/components/src/components/UtilityCard/UtilityCard.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.tsx
@@ -77,7 +77,7 @@ export const UtilityCard: React.FC<UtilityCardProps> = ({
         padding={{ _: "d4", md: "d6" }}
         w={{ _: "56px", md: "56px" }}
       >
-        <Box.div aria-hidden="true">{emoji}</Box.div>
+        <Box.span aria-hidden="true">{emoji}</Box.span>
       </Box.div>
 
       <Box.div

--- a/packages/components/src/components/UtilityCard/UtilityCard.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.tsx
@@ -77,7 +77,7 @@ export const UtilityCard: React.FC<UtilityCardProps> = ({
         padding={{ _: "d4", md: "d6" }}
         w={{ _: "56px", md: "56px" }}
       >
-        {emoji}
+        <Box.div aria-hidden="true">{emoji}</Box.div>
       </Box.div>
 
       <Box.div

--- a/packages/components/src/components/UtilityCard/UtilityCard.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.tsx
@@ -9,7 +9,7 @@ export enum InteractiveElementTypeUtilityCard {
 }
 
 export type UtilityCardProps = {
-  /** Sets the category emoji */
+  /** Sets the an emoji for the card */
   emoji: string;
   /** Sets the title to be rendered as h2 */
   title: string;
@@ -77,7 +77,7 @@ export const UtilityCard: React.FC<UtilityCardProps> = ({
         padding={{ _: "d4", md: "d6" }}
         w={{ _: "56px", md: "56px" }}
       >
-        <Text.p>{emoji}</Text.p>
+        {emoji}
       </Box.div>
 
       <Box.div

--- a/packages/components/src/components/UtilityCard/UtilityCard.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.tsx
@@ -9,8 +9,8 @@ export enum InteractiveElementTypeUtilityCard {
 }
 
 export type UtilityCardProps = {
-  /** Sets the card image source */
-  imageSrc: string;
+  /** Sets the category emoji */
+  emoji: string;
   /** Sets the title to be rendered as h2 */
   title: string;
   /** Sets the type of the clickable element */
@@ -37,7 +37,7 @@ const interactiveBg = {
 
 export const UtilityCard: React.FC<UtilityCardProps> = ({
   as = "div",
-  imageSrc,
+  emoji,
   interactiveElementType,
   title,
   categoryTag,
@@ -77,7 +77,7 @@ export const UtilityCard: React.FC<UtilityCardProps> = ({
         padding={{ _: "d4", md: "d6" }}
         w={{ _: "56px", md: "56px" }}
       >
-        <Box.img alt="" aria-hidden h="24px" src={imageSrc} w="24px" />
+        <Text.p>{emoji}</Text.p>
       </Box.div>
 
       <Box.div


### PR DESCRIPTION
## Description of the change
Now we save the category specific emoji in the DB so we don't need to load any emoji-images anymore.

- update UtilityCard to use emoji/string instead of image


## Type of change

- [x] New feature (non-breaking change that adds functionality)



<img width="1040" alt="Screenshot 2024-11-01 at 14 17 00" src="https://github.com/user-attachments/assets/5826de09-2001-4200-a3f9-b7baf901ed41">



### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.


This should only be merged with the relevant change in the Localitos/Backend (WIP)