### PR TITLE
fix(components): import named styled instead of default fixing warning

### DIFF
--- a/packages/components/src/components/List/OrderedList.tsx
+++ b/packages/components/src/components/List/OrderedList.tsx
@@ -1,4 +1,4 @@
-import styled from "@xstyled/styled-components";
+import { styled } from "@xstyled/styled-components";
 import React from "react";
 import { Box, BoxProps } from "../../primitives/Box";
 

--- a/packages/components/src/components/List/UnorderedList.tsx
+++ b/packages/components/src/components/List/UnorderedList.tsx
@@ -1,4 +1,4 @@
-import styled from "@xstyled/styled-components";
+import { styled } from "@xstyled/styled-components";
 import React from "react";
 import { Box, BoxProps } from "../../primitives/Box";
 


### PR DESCRIPTION
## Description of the change

- Change styled default import by named on components fixing a warning https://github.com/Localitos/pluto/pull/1767/files#file-packages-components-src-components-list-orderedlist-tsx-L2

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Non-Breaking Change (change to existing functionality)
