### PR TITLE
feat: remove default link tag from interactive content card

### DIFF
--- a/.changeset/late-plants-clap.md
+++ b/.changeset/late-plants-clap.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/components": minor
+---
+
+[ContentCard]
+
+- Removed the default link wrapper tag when the component is set to `InteractiveElementType.Card`

--- a/packages/components/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.stories.tsx
@@ -51,6 +51,7 @@ WithAnchor.args = {
 export const ClickableCard: Story = Template.bind({});
 ClickableCard.args = {
   ...defaultProps,
+  as: "a",
   interactiveElementType: InteractiveElementType.Card,
   href,
 };

--- a/packages/components/src/components/ContentCard/ContentCard.test.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.test.tsx
@@ -51,6 +51,7 @@ describe("<ContentCard>", () => {
   it('renders card as link when interactive element type is "card"', () => {
     render(
       <ContentCardMock
+        as="a"
         href={HREF}
         interactiveElementType={InteractiveElementType.Card}
       />,
@@ -142,6 +143,7 @@ describe("<ContentCard>", () => {
 
     render(
       <ContentCardMock
+        as="a"
         href={HREF}
         interactiveElementType={InteractiveElementType.Card}
         onClick={onClick}

--- a/packages/components/src/components/ContentCard/ContentCard.tsx
+++ b/packages/components/src/components/ContentCard/ContentCard.tsx
@@ -143,7 +143,7 @@ export const ContentCard = ({
       position="relative"
     >
       <Box.div
-        as={isCardInteractive ? "a" : as}
+        as={as}
         backgroundColor={backgroundColor[background]}
         display="flex"
         flexDirection={


### PR DESCRIPTION
## Description of the change

While working on adding the Link from react router to the ContentCard component in the Partners list page, I noticed that it was creating the following issue:
![image](https://github.com/user-attachments/assets/cbf83f31-9961-4098-b707-5c0f755833df)

This is happening because when using the `InteractiveElementType.Card`, the component automatically wraps the card in an <a> tag.
To avoid this issue and allow the card to be interactive without always being a link, I removed this behavior, letting the user add a link tag if needed.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
