### PR TITLE
feat: use proper states and make UtilityCard more generic

### DIFF
--- a/.changeset/green-keys-marry.md
+++ b/.changeset/green-keys-marry.md
@@ -1,0 +1,17 @@
+---
+"@localyze-pluto/components": major
+---
+
+UtilityCard:
+
+Breaking Change:
+
+- Removed the `interactiveElementType` prop in order to add two new states properties `hoverable` and `clickable`
+- Renamed `categoryTag` to `subTitle` to make it more generic
+- `onClick` prop is only required when using `clickable` as true
+
+Minor:
+
+- Added `hoverable` and `clickable` to have more control of state of the card
+- Added `emojiWrapperSize` prop with options `small` and `large` so it's adaptable to different use cases
+- Added `indicator` to add a helper element to the top right of the card

--- a/.changeset/proud-apes-confess.md
+++ b/.changeset/proud-apes-confess.md
@@ -1,0 +1,7 @@
+---
+"@localyze-pluto/components": major
+---
+
+[UtilityCard]:
+
+- Replaced the `status` prop with a new `content` prop to make the UtilityCard component more generic and flexible. The content prop allows rendering any kind of detail, such as a badge or text.

--- a/packages/components/src/components/UtilityCard/UtilityCard.stories.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import React from "react";
 import { Box } from "../../primitives/Box";
-import { UtilityCard, InteractiveElementTypeUtilityCard } from "./UtilityCard";
+import { Badge } from "../Badge";
+import { Paragraph } from "../Paragraph";
+import { UtilityCard } from "./UtilityCard";
 
 export default {
   component: UtilityCard,
@@ -17,11 +19,10 @@ const Template = (args: React.ComponentProps<typeof UtilityCard>) => {
 const onClick = (): void =>
   alert("This is what happens when you click on the card");
 
-const defaultProps = {
-  emoji: "❤️",
-  title: "The card title",
-  categoryTag: "The category tag",
-  serviceTag: "Concierge Services",
+const defaultProps: React.ComponentProps<typeof UtilityCard> = {
+  emoji: "🧳️",
+  title: "My Service",
+  subTitle: "Housing",
 };
 
 export const Default: Story = Template.bind({});
@@ -29,17 +30,68 @@ Default.args = {
   ...defaultProps,
 };
 
-export const CardWithBadge: Story = Template.bind({});
-CardWithBadge.args = {
+export const WithLargeEmojiWrapper: Story = Template.bind({});
+WithLargeEmojiWrapper.args = {
   ...defaultProps,
-  status: "In progress",
+  emoji: "🏠️",
+  emojiWrapperSize: "large",
+  content: (
+    <Paragraph marginBottom="d0">
+      Step-by-step guide, document lists & articles and support via chat and
+      phone, incl.
+    </Paragraph>
+  ),
 };
 
-export const ClickableCard: Story = Template.bind({});
-ClickableCard.args = {
+export const WithContent: Story = Template.bind({});
+WithContent.args = {
   ...defaultProps,
-  interactiveElementType: InteractiveElementTypeUtilityCard.Card,
+  content: (
+    <Paragraph marginBottom="d0">
+      This is the content of the card. It can be a paragraph, a list, or any
+      other component.
+    </Paragraph>
+  ),
+};
+
+export const WithIndicator: Story = Template.bind({});
+WithIndicator.args = {
+  ...defaultProps,
+  emojiWrapperSize: "large",
+  indicator: (
+    <Badge color="green" icon="circle-check">
+      Included in your support
+    </Badge>
+  ),
+  content: (
+    <Paragraph marginBottom="d0" size="small">
+      When using My Service, you get access to a lot of cool features and be
+      able to do a lot of cool things.
+    </Paragraph>
+  ),
+};
+
+export const WithBadge: Story = Template.bind({});
+WithBadge.args = {
+  ...defaultProps,
+  content: (
+    <Box.div marginTop="d3">
+      <Badge>In progress</Badge>
+    </Box.div>
+  ),
+};
+
+export const Clickable: Story = Template.bind({});
+Clickable.args = {
+  ...defaultProps,
+  clickable: true,
   onClick,
+};
+
+export const Hoverable: Story = Template.bind({});
+Hoverable.args = {
+  ...defaultProps,
+  hoverable: true,
 };
 
 export const InList = (): JSX.Element => {
@@ -54,10 +106,10 @@ export const InList = (): JSX.Element => {
         <Template {...defaultProps} />
       </Box.li>
       <Box.li>
-        <Template {...defaultProps} />
+        <Template {...defaultProps} emoji="👨‍👩‍👦" title="Another service" />
       </Box.li>
       <Box.li>
-        <Template {...defaultProps} emoji={"🙈"} />
+        <Template {...defaultProps} emoji="🙈" title="One more service" />
       </Box.li>
     </Box.ul>
   );

--- a/packages/components/src/components/UtilityCard/UtilityCard.test.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.test.tsx
@@ -1,59 +1,57 @@
 import React from "react";
 import { render, screen, RenderResult } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import {
-  UtilityCard,
-  UtilityCardProps,
-  InteractiveElementTypeUtilityCard,
-} from "./UtilityCard";
+import { UtilityCard, UtilityCardProps } from "./UtilityCard";
 
-const onClick = jest.fn();
+const onClickMock = jest.fn();
 
 const defaultMockProps = {
   emoji: "📦",
-  categoryTag: "a service tag",
+  subTitle: "a service tag",
   title: "Good title!",
 };
 
-const UtilityCardMock = (props: Partial<UtilityCardProps>) => {
+const UtilityCardMock = (
+  props?: Partial<UtilityCardProps>,
+): React.JSX.Element => {
+  const { clickable, onClick = onClickMock, ...restProps } = props || {};
+
   const defaultProps: UtilityCardProps = {
     as: "div",
     ...defaultMockProps,
+    ...(clickable ? { clickable, onClick } : { clickable: false }),
   };
 
-  return <UtilityCard {...defaultProps} {...props} />;
+  return <UtilityCard {...defaultProps} {...restProps} />;
 };
 
 const renderDefaultCard = (): RenderResult => {
   return render(<UtilityCardMock />);
 };
 
-const renderCardWithBadge = (): RenderResult => {
-  return render(<UtilityCardMock status="In progress" />);
-};
-
-const renderClickableCard = (): RenderResult => {
+const renderCardWithContent = (): RenderResult => {
   return render(
     <UtilityCardMock
-      interactiveElementType={InteractiveElementTypeUtilityCard.Card}
-      onClick={onClick}
+      content={<div>Extra content added to the card as details</div>}
     />,
   );
 };
 
+const renderClickableCard = (): RenderResult => {
+  return render(<UtilityCardMock clickable onClick={onClickMock} />);
+};
+
 describe("<UtilityCard>", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("Default card", () => {
     it("renders text props", () => {
       renderDefaultCard();
 
       expect(screen.getByText("Good title!")).toBeVisible();
       expect(screen.getByText("a service tag")).toBeVisible();
-    });
-
-    it("does not render a badge", () => {
-      renderDefaultCard();
-
-      expect(screen.queryByText("In progress")).not.toBeInTheDocument();
     });
 
     it("renders an emoji", () => {
@@ -63,11 +61,13 @@ describe("<UtilityCard>", () => {
     });
   });
 
-  describe("Card with badge", () => {
-    it("renders a badge", () => {
-      renderCardWithBadge();
+  describe("Card with content", () => {
+    it("renders content when provided", () => {
+      renderCardWithContent();
 
-      expect(screen.getByText("In progress")).toBeInTheDocument();
+      expect(
+        screen.getByText("Extra content added to the card as details"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -89,7 +89,7 @@ describe("<UtilityCard>", () => {
       card.addEventListener("click", (event) => event.preventDefault(), false);
 
       await user.click(card);
-      expect(onClick).toHaveBeenCalled();
+      expect(onClickMock).toHaveBeenCalled();
     });
   });
 

--- a/packages/components/src/components/UtilityCard/UtilityCard.tsx
+++ b/packages/components/src/components/UtilityCard/UtilityCard.tsx
@@ -1,118 +1,150 @@
-import React from "react";
+import React, { ReactElement } from "react";
+import { SystemProp, Theme } from "@localyze-pluto/theme";
 import { Box } from "../../primitives/Box";
-import { Badge } from "../Badge";
 import { Icon } from "../Icon";
-import { Text } from "../../primitives/Text";
+import { Heading } from "../Heading";
+import { Paragraph } from "../Paragraph";
 
-export enum InteractiveElementTypeUtilityCard {
-  Card = "card",
-}
+// Discriminated union to make sure 'onClick' is only required when using 'clickable' as true
+type ClickableProps =
+  | {
+      /** Sets the card to be clickable */
+      clickable: true;
+      /**
+       * Callback function to be used to invoke onClicks
+       * Only required when clickable is true
+       */
+      onClick: React.MouseEventHandler;
+    }
+  | { clickable?: false; onClick?: never };
 
-export type UtilityCardProps = {
-  /** Sets the an emoji for the card */
+type EmojiWrapperSize = "large" | "small";
+
+export type UtilityCardProps = ClickableProps & {
+  /** Sets an emoji for the card */
   emoji: string;
   /** Sets the title to be rendered as h2 */
   title: string;
-  /** Sets the type of the clickable element */
-  interactiveElementType?: InteractiveElementTypeUtilityCard;
-  /** Text describing the kind of category provided */
-  categoryTag: string;
-  /** Text describing the current status of the category as a badge */
-  status?: string;
+  /** Text to be displayed as a sub title */
+  subTitle: string;
+  /** Optional content to display in the card, allowing to set additional details. */
+  content?: ReactElement;
   /** Used by StyledComponents to render the component as a specific tag. If href is passed it'll be rendered as "a" */
   as?: React.ComponentProps<typeof Box.div>["as"];
-  /** Callback function to be used to invoke onClicks */
-  onClick?: React.MouseEventHandler;
+  /** Sets the size of the emoji wrapper */
+  emojiWrapperSize?: EmojiWrapperSize;
+  /** Sets the card to be hoverable */
+  hoverable?: boolean;
+  /** A helper element to be displayed on the top right of the card */
+  indicator?: ReactElement;
 };
 
-const cardBg = {
-  _: "colorBackgroundWeakest",
-};
-
-const interactiveBg = {
-  active: "colorBackgroundWeak",
-  hover: "colorBackgroundWeak",
-  ...cardBg,
+const getStylesByEmojiWrapperSize: {
+  [key in EmojiWrapperSize]: {
+    borderRadius: SystemProp<keyof Theme["radii"], Theme>;
+    h: string;
+    minWidth: string;
+    w: string;
+    padding: SystemProp<keyof Theme["space"], Theme>;
+  };
+} = {
+  large: {
+    borderRadius: "borderRadius40",
+    h: "88px",
+    minWidth: "88px",
+    w: "88px",
+    padding: "d6",
+  },
+  small: {
+    borderRadius: "borderRadius30",
+    h: "56px",
+    minWidth: "56px",
+    w: "56px",
+    padding: "d4",
+  },
 };
 
 export const UtilityCard: React.FC<UtilityCardProps> = ({
   as = "div",
   emoji,
-  interactiveElementType,
   title,
-  categoryTag,
-  status,
+  subTitle,
+  content,
   onClick,
+  emojiWrapperSize = "small",
+  hoverable = false,
+  clickable = false,
+  indicator,
 }) => {
-  const isCardInteractive =
-    InteractiveElementTypeUtilityCard.Card === interactiveElementType;
-
-  const interactiveElementProps = {
-    onClick,
-    cursor: "pointer",
-    border: 0,
-  };
-
   return (
     <Box.div
-      as={isCardInteractive ? "button" : as}
-      backgroundColor={isCardInteractive ? interactiveBg : cardBg}
+      alignItems="flex-start"
+      as={clickable ? "button" : as}
+      backgroundColor={{
+        _: "colorBackgroundWeakest",
+        active: "colorBackgroundWeak",
+        hover: hoverable ? "colorBackgroundWeak" : undefined,
+      }}
+      border={clickable ? "0" : "none"}
       borderRadius="borderRadius30"
+      cursor={clickable ? "pointer" : "default"}
       display="flex"
-      flexDirection={{ lg: "row" }}
+      gap={emojiWrapperSize === "large" ? "d6" : "d2_5"}
+      onClick={clickable ? onClick : undefined}
       outlineColor={{ focus: "colorBorderPrimary" }}
-      padding="d4"
+      padding={emojiWrapperSize === "large" ? "d6" : "d4"}
       w="100%"
-      {...(isCardInteractive ? interactiveElementProps : {})}
     >
       <Box.div
         alignItems="center"
         backgroundColor="bgPrimary"
-        borderRadius="borderRadius30"
         display="flex"
-        h={{ _: "56px", md: "56px" }}
         justifyContent="center"
-        marginRight="d4"
-        minWidth={{ _: "24px", md: "24px" }}
-        padding={{ _: "d4", md: "d6" }}
-        w={{ _: "56px", md: "56px" }}
+        {...getStylesByEmojiWrapperSize[emojiWrapperSize]}
       >
-        <Box.span aria-hidden="true">{emoji}</Box.span>
+        <Box.span
+          aria-hidden={true}
+          fontSize={emojiWrapperSize === "large" ? "fontSize70" : "fontSize40"}
+        >
+          {emoji}
+        </Box.span>
       </Box.div>
 
       <Box.div
         display="flex"
         flexDirection="column"
-        marginRight="d4"
+        gap={emojiWrapperSize === "large" ? "d1" : "d0"}
+        position="relative"
         textAlign="left"
         w="100%"
       >
-        <Text.p
-          color="colorTextStronger"
-          fontSize="fontSize10"
-          fontWeight="fontWeightMedium"
-          lineHeight="lineHeight10"
-          margin="0 0 d1"
-        >
-          {categoryTag}
-        </Text.p>
-        <Text.h2
-          fontSize="fontSize30"
-          fontWeight="fontWeightBold"
-          margin="m0 m0 d3"
-        >
-          {title}
-        </Text.h2>
-        {status && (
-          <Box.div>
-            <Badge>{status}</Badge>
+        {indicator && (
+          <Box.div
+            position={{
+              _: "static",
+              sm: "absolute",
+            }}
+            right={{
+              sm: "0",
+            }}
+          >
+            {indicator}
           </Box.div>
         )}
+        <Paragraph color="contentSecondary" marginBottom="d0" size="small">
+          {subTitle}
+        </Paragraph>
+        <Heading as="h2" marginBottom="d0" size="title-body">
+          {title}
+        </Heading>
+        {content}
       </Box.div>
 
-      <Box.div margin="d2">
-        <Icon decorative icon="chevron-right" size="sizeIcon20" />
-      </Box.div>
+      {clickable && (
+        <Box.div margin="d2">
+          <Icon decorative icon="chevron-right" size="sizeIcon20" />
+        </Box.div>
+      )}
     </Box.div>
   );
 };


### PR DESCRIPTION
## Description of the change

Breaking Change:

- Removed the `interactiveElementType` prop in order to add two new states properties `hoverable` and `clickable`
- Renamed `categoryTag` to `subTitle` to make it more generic
- `onClick` prop is only required when using `clickable` as true

Minor:

- Added `hoverable` and `clickable` to have more control of state of the card
- Added `emojiWrapperSize` prop with options `small` and `large` so it's adaptable to different use cases
- Added `indicator` to add a helper element to the top right of the card


## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
