### PR TITLE
feat: make improvements to Menu component

### DIFF
--- a/.changeset/fast-mice-applaud.md
+++ b/.changeset/fast-mice-applaud.md
@@ -1,0 +1,11 @@
+---
+"@localyze-pluto/components": major
+---
+
+[Menu]:
+
+- Breaking change: Removed the unnecessary `div` wrapper from the `Menu` component; props are now passed directly to the Menu.
+- Improved focus behavior for menu items by adding a background color to the focused item
+- Added a new `customStore` prop to enable custom store settings and support different behaviors, such as placement
+- Set a default `gutter` value of 3 for the Menu component to align with the Figma design
+- Introduced a `menuButtonProps` prop to enable passing props to the default menu button

--- a/packages/components/src/components/Menu/Menu.stories.tsx
+++ b/packages/components/src/components/Menu/Menu.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from "../Button";
 import { Box } from "../../primitives/Box";
 import { Icon } from "../Icon";
 import { Menu, MenuItemProps } from "./Menu";
+import { useMenuStore } from "./index";
 
 const meta: Meta<typeof Menu> = {
   title: "Components/Menu",
@@ -15,7 +16,7 @@ const meta: Meta<typeof Menu> = {
 export default meta;
 type Story = StoryObj<typeof Menu>;
 
-const DefaultMenu = (): JSX.Element => {
+const DefaultMenu = (): React.JSX.Element => {
   const items: MenuItemProps[] = [
     {
       onClick: noop,
@@ -35,7 +36,7 @@ const DefaultMenu = (): JSX.Element => {
 };
 
 export const Default: Story = {
-  render: (): JSX.Element => <DefaultMenu />,
+  render: (): React.JSX.Element => <DefaultMenu />,
 };
 
 Default.parameters = {
@@ -45,7 +46,7 @@ Default.parameters = {
   },
 };
 
-const CustomButtonMenu = (): JSX.Element => {
+const CustomButtonMenu = (): React.JSX.Element => {
   const items: MenuItemProps[] = [
     {
       onClick: noop,
@@ -67,7 +68,38 @@ const CustomButtonMenu = (): JSX.Element => {
 };
 
 export const WithCustomMenuButton: Story = {
-  render: (): JSX.Element => <CustomButtonMenu />,
+  render: (): React.JSX.Element => <CustomButtonMenu />,
+};
+
+export const WithCustomStoreAndMenuButtonProps: Story = {
+  render: (): React.JSX.Element => {
+    const store = useMenuStore({
+      placement: "right-start",
+    });
+
+    const items: MenuItemProps[] = [
+      {
+        onClick: noop,
+        label: "Option 1",
+      },
+      {
+        onClick: noop,
+        label: "Option 2",
+      },
+    ];
+
+    return (
+      <Box.div minHeight="100px">
+        <Menu
+          customStore={store}
+          items={items}
+          menuButtonProps={{
+            marginLeft: "d10",
+          }}
+        />
+      </Box.div>
+    );
+  },
 };
 
 const ManyItemsMenu = (): JSX.Element => {
@@ -122,10 +154,10 @@ const ManyItemsMenu = (): JSX.Element => {
 };
 
 export const WithManyItems: Story = {
-  render: (): JSX.Element => <ManyItemsMenu />,
+  render: (): React.JSX.Element => <ManyItemsMenu />,
 };
 
-const DisabledButtonsMenu = (): JSX.Element => {
+const DisabledButtonsMenu = (): React.JSX.Element => {
   const items: MenuItemProps[] = [
     {
       onClick: noop,
@@ -148,18 +180,18 @@ const DisabledButtonsMenu = (): JSX.Element => {
   ];
 
   return (
-    <Box.div minHeight="400px">
+    <Box.div minHeight="200px">
       <Menu items={items} />
     </Box.div>
   );
 };
 
 export const WithDisabledButtons: Story = {
-  render: (): JSX.Element => <DisabledButtonsMenu />,
+  render: (): React.JSX.Element => <DisabledButtonsMenu />,
 };
 
 export const WithLongMenuItems: Story = {
-  render: (): JSX.Element => {
+  render: (): React.JSX.Element => {
     const items: MenuItemProps[] = [
       {
         onClick: noop,
@@ -176,7 +208,7 @@ export const WithLongMenuItems: Story = {
     ];
 
     return (
-      <Box.div minHeight="100px">
+      <Box.div minHeight="200px">
         <Menu items={items} />
       </Box.div>
     );
@@ -184,7 +216,7 @@ export const WithLongMenuItems: Story = {
 };
 
 export const WithIcons: Story = {
-  render: (): JSX.Element => {
+  render: (): React.JSX.Element => {
     const items: MenuItemProps[] = [
       {
         onClick: noop,

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -4,6 +4,7 @@ import {
   MenuButton,
   MenuItem,
   useMenuStore,
+  MenuProps as AriakitMenuProps,
 } from "@ariakit/react";
 import map from "lodash/map";
 import { Button } from "../Button";
@@ -15,13 +16,17 @@ export type MenuItemProps = {
   disabled?: boolean;
 };
 
-export type MenuProps = {
+export type MenuProps = Omit<AriakitMenuProps, "store"> & {
   /** The button element to open the menu and display the list of menu items. */
-  menuButton?: JSX.Element;
+  menuButton?: React.JSX.Element;
   /** The list of menu items. */
   items: MenuItemProps[];
   /** The expanded menu z-index. */
   menuZIndex?: HTMLDivElement["style"]["zIndex"];
+  /** Custom store for the menu. */
+  customStore?: ReturnType<typeof useMenuStore>;
+  /** Props for the default menu button. */
+  menuButtonProps?: BoxProps;
 };
 
 const VerticalEllipsisButton = (
@@ -40,24 +45,42 @@ const FullWidthButton = ({ ...props }) => (
 
 /** A menu is a button element that opens a menu with items. */
 const Menu = React.forwardRef<HTMLButtonElement, BoxProps & MenuProps>(
-  ({ menuButton, items, menuZIndex = "auto", ...props }, ref) => {
-    const store = useMenuStore();
+  (
+    {
+      menuButton,
+      items,
+      menuZIndex = "auto",
+      customStore,
+      menuButtonProps,
+      ...props
+    },
+    ref,
+  ) => {
+    const store = useMenuStore({
+      store: customStore,
+    });
 
     const button = menuButton || VerticalEllipsisButton;
 
     return (
-      <Box.div {...props}>
+      <>
         <MenuButton
           render={(props) =>
             React.cloneElement(button, {
               ...props,
+              ...menuButtonProps,
               ref,
             })
           }
           store={store}
         />
 
-        <AriakitMenu store={store} style={{ zIndex: menuZIndex }}>
+        <AriakitMenu
+          gutter={3}
+          store={store}
+          style={{ zIndex: menuZIndex }}
+          {...props}
+        >
           <Box.div
             backgroundColor="colorBackground"
             borderRadius="borderRadius20"
@@ -71,41 +94,48 @@ const Menu = React.forwardRef<HTMLButtonElement, BoxProps & MenuProps>(
             overflow="hidden"
           >
             {map(items, ({ label, onClick, disabled }, i) => (
-              <MenuItem key={i}>
-                <Box.div
-                  backgroundColor={{
-                    _: "colorBackground",
-                    hover: disabled
-                      ? "colorBackground"
-                      : "colorBackgroundWeakest",
-                  }}
-                >
-                  <Box.button
-                    alignItems="center"
-                    as={FullWidthButton}
-                    disabled={disabled}
-                    justifyContent="flex-start"
-                    onClick={onClick}
-                    padding="d0"
-                    px="d4"
-                    py="d2"
-                    variant="ghost"
-                    w="100%"
+              <MenuItem
+                key={i}
+                render={
+                  <Box.div
+                    backgroundColor={{
+                      _: "colorBackground",
+                      focusVisible: "colorBackgroundWeakest",
+                      hover: disabled
+                        ? "colorBackground"
+                        : "colorBackgroundWeakest",
+                    }}
+                    outline={{
+                      focusVisible: "none",
+                    }}
                   >
-                    <Box.span
-                      color={disabled ? "colorText" : "colorTextStrongest"}
-                      textAlign="left"
+                    <Box.button
+                      alignItems="center"
+                      as={FullWidthButton}
+                      disabled={disabled}
+                      justifyContent="flex-start"
+                      onClick={onClick}
+                      padding="d0"
+                      px="d4"
+                      py="d2"
+                      variant="ghost"
                       w="100%"
                     >
-                      {label}
-                    </Box.span>
-                  </Box.button>
-                </Box.div>
-              </MenuItem>
+                      <Box.span
+                        color={disabled ? "colorText" : "colorTextStrongest"}
+                        textAlign="left"
+                        w="100%"
+                      >
+                        {label}
+                      </Box.span>
+                    </Box.button>
+                  </Box.div>
+                }
+              />
             ))}
           </Box.div>
         </AriakitMenu>
-      </Box.div>
+      </>
     );
   },
 );

--- a/packages/components/src/components/Menu/index.ts
+++ b/packages/components/src/components/Menu/index.ts
@@ -1,1 +1,3 @@
 export * from "./Menu";
+export { useMenuStore } from "@ariakit/react/menu";
+export type { MenuStoreProps } from "@ariakit/react/menu";


### PR DESCRIPTION
## Description of the change

While working on the Partner Preferences page and adding the menu `Set preferences` there, I noticed that we had some issues with the Menu component and decided to make some improvements. Changelog:

* Breaking change: Removed the unnecessary div wrapper from the Menu component; props are now passed directly to the Menu.
* Improved focus behavior for menu items by adding a background color to the focused item
* Added a new customStore prop to enable custom store settings and support different behaviors, such as placement
* Set a default gutter value of 3 for the Menu component to align with the Figma design
* Introduced a menuButtonProps prop to enable passing props to the default menu button

This component was limited to its own store. With this change, we can now customize things like the gutter, a custom store, and menu popover position. We can also import the store directly from Pluto instead of ariakit.

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
