### PR TITLE
add new Combobox component

### DIFF
--- a/.changeset/early-badgers-trade.md
+++ b/.changeset/early-badgers-trade.md
@@ -1,0 +1,9 @@
+---
+"@localyze-pluto/components": minor
+---
+
+New Combobox component:
+
+- Combines a text input and a popover to allow users to filter from long lists of options
+- Can be used as a standalone component or composed with other components such as `ComboboxInput`, `ComboboxPopover`, `ComboboxItem`, and `ComboboxProvider`
+- Supports generic type for the options list

--- a/packages/components/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/components/src/components/Combobox/Combobox.stories.tsx
@@ -1,0 +1,246 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import React, { useEffect, useState } from "react";
+import toLower from "lodash/toLower";
+import includes from "lodash/includes";
+import map from "lodash/map";
+import { useComboboxStore } from "@ariakit/react";
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import find from "lodash/find";
+import { Box } from "../../primitives/Box";
+import { Label } from "../Label";
+import { HelpText } from "../HelpText";
+import { Button } from "../Button";
+import { Combobox, ComboboxItemProps, ComboboxProps } from "./Combobox";
+import { ComboboxInput } from "./ComboboxInput/ComboboxInput";
+import { ComboboxPopover } from "./ComboboxPopover/ComboboxPopover";
+import { ComboboxItem } from "./ComboboxItem/ComboboxItem";
+
+export default {
+  component: Combobox,
+  title: "Components/Combobox",
+} as Meta<typeof Combobox>;
+
+const items: ComboboxItemProps[] = [
+  { value: "1", label: "Option One" },
+  { value: "2", label: "Option Two" },
+  { value: "Option Three", label: "Option Three" },
+  { value: "Option Four", label: "Option Four" },
+];
+
+const Template: StoryFn<ComboboxProps> = ({ children, ...props }) => (
+  <Combobox {...props}>{children}</Combobox>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  items,
+  placeholder: "Select an option",
+  noResultsMessage: "No results found",
+  filterItem: true,
+  hasError: false,
+};
+Default.parameters = {
+  docs: {
+    description: {
+      story: "The combobox will filter the items based on the input value.",
+    },
+  },
+};
+
+export const WithOnChange = (): React.JSX.Element => (
+  <Combobox
+    items={items}
+    onChangeInput={(event) => {
+      // eslint-disable-next-line no-console
+      console.log(event.target.value);
+    }}
+    placeholder="Select an option"
+  />
+);
+WithOnChange.parameters = {
+  docs: {
+    description: {
+      story:
+        "The combobox will call the `onChangeInput` function when the input value changes.",
+    },
+  },
+};
+
+export const WithOnSelectItem = (): React.JSX.Element => (
+  <Combobox
+    items={items}
+    onSelectItem={(value) => {
+      // eslint-disable-next-line no-console
+      console.log(value);
+    }}
+    placeholder="Select an option"
+  />
+);
+WithOnSelectItem.parameters = {
+  docs: {
+    description: {
+      story:
+        "The combobox will call the `onSelectItem` function when an option is selected.",
+    },
+  },
+};
+
+export const WithLongItem = (): React.JSX.Element => {
+  const longItem = {
+    value:
+      "Option Five which is a really long item and should overflow to the next line",
+    label:
+      "Option Five which is a really long item and should overflow to the next line",
+  };
+
+  return (
+    <Box.div w="250px">
+      <Label htmlFor="select-option">Select an option</Label>
+      <Combobox id="select-option" items={[...items, longItem]} name="select" />
+    </Box.div>
+  );
+};
+
+type CustomItem = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export const WithCustomFilterItem = (): React.JSX.Element => {
+  const customItems: CustomItem[] = [
+    ...items,
+    { value: "New option 1", label: "New option 1", disabled: true },
+    { value: "New option 2", label: "New option 2", disabled: true },
+  ];
+
+  const customFilter = (inputValue: string, item: CustomItem): boolean =>
+    includes(toLower(item.label), toLower(inputValue)) && !item.disabled;
+
+  return <Combobox filterItem={customFilter} items={customItems} />;
+};
+WithCustomFilterItem.parameters = {
+  docs: {
+    description: {
+      story:
+        "The combobox will filter the items based on a given function " +
+        "that filters the items based on the input value and the item.",
+    },
+  },
+};
+
+export const WithReactHookForm = (): React.JSX.Element => {
+  interface FormInputs {
+    item: string;
+  }
+
+  const [selectedLabel, setSelectedLabel] = useState<string | undefined>("");
+  const { control, handleSubmit, clearErrors, formState } = useForm({
+    defaultValues: {
+      item: "",
+    },
+  });
+
+  useEffect(() => {
+    clearErrors();
+  }, [clearErrors, formState.isDirty]);
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const onSubmit: SubmitHandler<FormInputs> = (data) =>
+    alert(JSON.stringify(data, null, 2));
+
+  return (
+    <Box.form noValidate onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        control={control}
+        name="item"
+        render={({ field: { onChange, ...field }, fieldState }) => (
+          <>
+            <Label htmlFor="select-option" required>
+              Select an option
+            </Label>
+            <Combobox
+              {...field}
+              aria-describedby="select-option-help-text"
+              hasError={fieldState.invalid}
+              id="select-option"
+              items={items}
+              onChangeInput={(event) => {
+                onChange(event);
+                setSelectedLabel(event.target.value);
+              }}
+              onSelectItem={(value) => {
+                const label = find(items, ["value", value])?.label;
+                setSelectedLabel(label);
+                onChange(value);
+              }}
+              required
+              value={selectedLabel}
+            />
+            <HelpText id="select-option-help-text">
+              Please choose one of the options.
+            </HelpText>
+          </>
+        )}
+        rules={{ required: true }}
+      />
+      <Box.div marginTop="d6">
+        <Button type="submit" variant="primary">
+          Submit
+        </Button>
+      </Box.div>
+    </Box.form>
+  );
+};
+
+export const Composed = (): React.JSX.Element => {
+  const [selectedLabel, setSelectedLabel] = useState<string | undefined>("");
+  const store = useComboboxStore({
+    setSelectedValue: (value) => {
+      const label = find(items, ["value", value])?.label;
+      setSelectedLabel(label);
+    },
+  });
+
+  const customItems: CustomItem[] = [
+    ...items,
+    { value: "Option Five", label: "Option Five", disabled: true },
+    { value: "Option Six", label: "Option Six", disabled: true },
+  ];
+
+  return (
+    <>
+      <ComboboxInput
+        aria-label="Select an option"
+        leadingIcon="search"
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          setSelectedLabel(event.target.value);
+        }}
+        placeholder="Select an option"
+        store={store}
+        value={selectedLabel}
+      />
+      <ComboboxPopover store={store}>
+        {map(customItems, (item) => (
+          <ComboboxItem
+            disabled={item.disabled}
+            key={item.value}
+            store={store}
+            value={item.value}
+          >
+            {item.label}
+          </ComboboxItem>
+        ))}
+      </ComboboxPopover>
+    </>
+  );
+};
+Composed.parameters = {
+  docs: {
+    description: {
+      story:
+        "The combobox can be composed with the other Combobox components, " +
+        "like `ComboboxInput`, `ComboboxItem` and `ComboboxPopover`.",
+    },
+  },
+};

--- a/packages/components/src/components/Combobox/Combobox.test.tsx
+++ b/packages/components/src/components/Combobox/Combobox.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { Combobox } from "./Combobox";
+
+const SELECT_AN_OPTION_LABEL = "Select an option";
+
+describe("<Combobox />", () => {
+  const items = [
+    { label: "Item 1", value: "item-1" },
+    { label: "Item 2", value: "item-2" },
+    { label: "Item 3", value: "item-3" },
+  ];
+
+  it("renders list of items", async () => {
+    const user = userEvent.setup();
+    render(<Combobox items={items} />);
+
+    const combobox = screen.getByRole("combobox", {
+      name: SELECT_AN_OPTION_LABEL,
+    });
+
+    await user.click(combobox);
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+
+    expect(options[0]).toHaveTextContent("Item 1");
+    expect(options[1]).toHaveTextContent("Item 2");
+    expect(options[2]).toHaveTextContent("Item 3");
+  });
+
+  it("filters items", async () => {
+    const user = userEvent.setup();
+    render(<Combobox items={items} />);
+
+    const combobox = screen.getByRole("combobox", {
+      name: SELECT_AN_OPTION_LABEL,
+    });
+
+    await user.click(combobox);
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+
+    await user.type(combobox, "Item 1");
+
+    const filteredOptions = screen.getAllByRole("option");
+    expect(filteredOptions).toHaveLength(1);
+    expect(filteredOptions[0]).toHaveTextContent("Item 1");
+  });
+
+  it("shows no results message", async () => {
+    const user = userEvent.setup();
+    render(<Combobox items={items} />);
+
+    const combobox = screen.getByRole("combobox", {
+      name: SELECT_AN_OPTION_LABEL,
+    });
+
+    await user.click(combobox);
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+
+    await user.type(combobox, "Item 4");
+
+    const noResults = screen.getByRole("option", { name: "No results found" });
+    expect(noResults).toBeInTheDocument();
+  });
+
+  it("calls onChangeInput when typing", async () => {
+    const user = userEvent.setup();
+    const onChangeInput = jest.fn();
+    render(<Combobox items={items} onChangeInput={onChangeInput} />);
+
+    const combobox = screen.getByRole("combobox", {
+      name: SELECT_AN_OPTION_LABEL,
+    });
+
+    await user.type(combobox, "Item 1");
+
+    expect(onChangeInput).toHaveBeenCalled();
+  });
+
+  it("calls onSelectItem when selecting an item", async () => {
+    const user = userEvent.setup();
+    const onSelectItem = jest.fn();
+    render(<Combobox items={items} onSelectItem={onSelectItem} />);
+
+    const combobox = screen.getByRole("combobox", {
+      name: SELECT_AN_OPTION_LABEL,
+    });
+
+    await user.click(combobox);
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+
+    await user.click(options[0]);
+
+    expect(onSelectItem).toHaveBeenCalledTimes(1);
+    expect(combobox).toHaveValue("Item 1");
+  });
+
+  it("renders placeholder", () => {
+    render(<Combobox items={items} placeholder="Placeholder" />);
+
+    const combobox = screen.getByPlaceholderText("Placeholder");
+
+    expect(combobox).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/Combobox/Combobox.tsx
+++ b/packages/components/src/components/Combobox/Combobox.tsx
@@ -1,0 +1,160 @@
+import React, { useState, forwardRef, ForwardedRef } from "react";
+import map from "lodash/map";
+import filter from "lodash/filter";
+import includes from "lodash/includes";
+import toLower from "lodash/toLower";
+import isBoolean from "lodash/isBoolean";
+import isFunction from "lodash/isFunction";
+import {
+  ComboboxProps as AriakitComboboxProps,
+  useComboboxStore,
+} from "@ariakit/react";
+import find from "lodash/find";
+import { BoxProps } from "../../primitives/Box";
+import { ComboboxInput } from "./ComboboxInput/ComboboxInput";
+import { ComboboxPopover } from "./ComboboxPopover/ComboboxPopover";
+import { ComboboxItem } from "./ComboboxItem/ComboboxItem";
+import { ComboboxProvider } from "./ComboboxProvider/ComboboxProvider";
+
+export type ComboboxItemProps = {
+  label: string;
+  value: string;
+  disabled?: boolean;
+};
+
+export type ComboboxProps<T extends ComboboxItemProps = ComboboxItemProps> =
+  BoxProps &
+    Omit<AriakitComboboxProps, "store"> & {
+      /** The options for the combobox. */
+      items: T[];
+      /** The function that will be called when the input value changes. */
+      onChangeInput?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+      /** The function that will be called when an option is selected. */
+      onSelectItem?: (value: string[] | string) => void;
+      /** The placeholder text for the input. */
+      placeholder?: string;
+      /** The message to display when there are no results. */
+      noResultsMessage?: string;
+      /**
+       * The function to filter the items based on the input value.
+       * If it is true, it will filter the items based on the input value.
+       * If it is a function, it will filter the items based on the input value and the item.
+       */
+      filterItem?: boolean | ((inputValue: string, item: T) => boolean);
+      /** Indicates if the combobox has an error. */
+      hasError?: boolean;
+      /** A custom store to be used instead of the default one. */
+      customStore?: AriakitComboboxProps["store"];
+    };
+
+const matchSorter = (
+  list: ComboboxItemProps[],
+  value: string,
+): ComboboxItemProps[] => {
+  return filter(list, (item) => includes(toLower(item.label), toLower(value)));
+};
+
+const getFilteredItems = <T extends ComboboxItemProps>(
+  items: T[],
+  searchValue: string,
+  filterItem?: boolean | ((inputValue: string, item: T) => boolean),
+): T[] => {
+  if (isBoolean(filterItem)) {
+    return filterItem
+      ? (matchSorter(items as ComboboxItemProps[], searchValue) as T[])
+      : items;
+  }
+  if (isFunction(filterItem)) {
+    return filter(items, (item) => filterItem(searchValue, item));
+  }
+  return items;
+};
+
+/**
+ * Combobox combines a text input and a popover to allow users to filter from long lists of options.
+ * @param {ComboboxProps} props - The props of the Combobox including the items, callbacks and other settings
+ * @param props.items - The options for the combobox
+ * @param props.onChangeInput - The function that will be called when the input value changes
+ * @param props.onSelectItem - The function that will be called when an option is selected
+ * @param props.placeholder - The placeholder text for the input
+ * @param props.noResultsMessage - The message to display when there are no results
+ * @param props.filterItem - The function to filter the items based on the input value.
+ * @param props.hasError - Indicates if the combobox has an error
+ * @param props.customStore - A custom store to be used instead of the default one
+ * @param {React.ForwardedRef<HTMLInputElement>} ref - A ref to the input element of the Combobox
+ * @returns {React.JSX.Element} - The actual Combobox component
+ */
+const ComboboxInner = <T extends ComboboxItemProps>(
+  {
+    items,
+    onChangeInput,
+    onSelectItem,
+    placeholder = "Select an option",
+    noResultsMessage = "No results found",
+    filterItem = true,
+    hasError,
+    customStore,
+    ...props
+  }: ComboboxProps<T>,
+  ref: React.ForwardedRef<HTMLInputElement>,
+): React.JSX.Element => {
+  const store = useComboboxStore({
+    store: customStore,
+  });
+  const selectedValue = store.getState().selectedValue;
+  const [searchValue, setSearchValue] = useState("");
+  const [selectedLabel, setSelectedLabel] = useState<string | undefined>("");
+
+  const filteredItems = getFilteredItems(items, searchValue, filterItem);
+
+  return (
+    <ComboboxProvider
+      setSelectedValue={(value) => onSelectItem?.(value)}
+      setValue={(value) => {
+        const label = find(items, ["value", value])?.label;
+        setSearchValue(value);
+        setSelectedLabel(label);
+      }}
+      store={store}
+      value={selectedLabel}
+    >
+      <ComboboxInput
+        aria-label="Select an option"
+        hasError={hasError}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          onChangeInput?.(event);
+          setSelectedLabel(event.target.value);
+        }}
+        placeholder={placeholder}
+        ref={ref}
+        store={store}
+        textOverflow="ellipsis"
+        {...props}
+      />
+      <ComboboxPopover sameWidth>
+        {filteredItems.length === 0 ? (
+          <ComboboxItem>{noResultsMessage}</ComboboxItem>
+        ) : (
+          map(filteredItems, (item) => (
+            <ComboboxItem
+              aria-selected={selectedValue === item.value}
+              data-value={item.value}
+              disabled={item.disabled}
+              key={item.value}
+              value={item.value}
+            >
+              {item.label}
+            </ComboboxItem>
+          ))
+        )}
+      </ComboboxPopover>
+    </ComboboxProvider>
+  );
+};
+
+const Combobox = forwardRef(ComboboxInner) as <T extends ComboboxItemProps>(
+  // eslint-disable-next-line no-use-before-define
+  props: ComboboxProps<T> & { ref?: ForwardedRef<HTMLInputElement> },
+) => ReturnType<typeof ComboboxInner>;
+
+export { Combobox };

--- a/packages/components/src/components/Combobox/ComboboxInput/ComboboxInput.test.tsx
+++ b/packages/components/src/components/Combobox/ComboboxInput/ComboboxInput.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import * as Ariakit from "@ariakit/react";
+import React from "react";
+import { userEvent, UserEvent } from "@testing-library/user-event";
+import { ComboboxInput, ComboboxInputProps } from "./ComboboxInput";
+
+const ComboboxInputMock = (props: Partial<ComboboxInputProps>) => {
+  const defaultProps: ComboboxInputProps = {
+    onChange: jest.fn(),
+    store: Ariakit.useComboboxStore(),
+    disabled: false,
+    onClick: jest.fn(),
+  };
+
+  return <ComboboxInput {...defaultProps} {...props} />;
+};
+
+describe("<ComboboxInput />", () => {
+  let user: UserEvent;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it("renders a combobox input correctly", () => {
+    render(<ComboboxInputMock />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("renders a combobox input with a placeholder", () => {
+    render(<ComboboxInputMock placeholder="Enter a city name" />);
+
+    expect(
+      screen.getByPlaceholderText("Enter a city name"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange when input changes", async () => {
+    const onChange = jest.fn();
+    render(<ComboboxInputMock onChange={onChange} />);
+
+    const input = screen.getByRole("combobox");
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.type(input, "input value");
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("calls onClick when input is clicked", async () => {
+    const onClick = jest.fn();
+    render(<ComboboxInputMock onClick={onClick} />);
+
+    const input = screen.getByRole("combobox");
+
+    expect(onClick).not.toHaveBeenCalled();
+
+    await userEvent.click(input);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("renders a disabled combobox input", () => {
+    render(<ComboboxInputMock disabled />);
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
+});

--- a/packages/components/src/components/Combobox/ComboboxInput/ComboboxInput.tsx
+++ b/packages/components/src/components/Combobox/ComboboxInput/ComboboxInput.tsx
@@ -1,0 +1,27 @@
+import {
+  Combobox as AriakitCombobox,
+  ComboboxProps as AriakitComboboxProps,
+} from "@ariakit/react";
+import React, { ComponentProps, forwardRef, ReactElement } from "react";
+import { Box } from "../../../primitives/Box";
+import { Input } from "../../Input";
+
+export type ComboboxInputProps = ComponentProps<typeof Box.input> &
+  Pick<AriakitComboboxProps, "onClick" | "store"> & {
+    as?: ReactElement<typeof Box.input>;
+  };
+
+export const ComboboxInput = forwardRef<HTMLInputElement, ComboboxInputProps>(
+  ({ as = <Input type="text" />, ...props }, ref) => {
+    return (
+      <AriakitCombobox
+        autoSelect
+        ref={ref}
+        render={as as ReactElement<typeof Box.input>}
+        {...props}
+      />
+    );
+  },
+);
+
+ComboboxInput.displayName = "ComboboxInput";

--- a/packages/components/src/components/Combobox/ComboboxItem/ComboboxItem.test.tsx
+++ b/packages/components/src/components/Combobox/ComboboxItem/ComboboxItem.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { useComboboxStore } from "@ariakit/react";
+import { ComboboxPopover } from "../ComboboxPopover/ComboboxPopover";
+import { ComboboxItem } from "./ComboboxItem";
+
+const ComboboxItemMock = () => {
+  const combobox = useComboboxStore({
+    open: true,
+  });
+
+  return (
+    <ComboboxPopover store={combobox}>
+      <ComboboxItem store={combobox}>Children content</ComboboxItem>
+    </ComboboxPopover>
+  );
+};
+
+describe("<ComboboxItem />", () => {
+  it("renders children when provided", async () => {
+    render(<ComboboxItemMock />);
+
+    expect(await screen.findByText("Children content")).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/Combobox/ComboboxItem/ComboboxItem.tsx
+++ b/packages/components/src/components/Combobox/ComboboxItem/ComboboxItem.tsx
@@ -1,0 +1,54 @@
+import React, { forwardRef } from "react";
+import {
+  ComboboxItem as AriakitComboboxItem,
+  ComboboxItemProps as AriakitComboboxItemProps,
+} from "@ariakit/react";
+import { Box } from "../../../primitives/Box";
+
+const DefaultItem = (
+  <Box.div
+    backgroundColor={{
+      _: "colorBackground",
+      activeItem: "colorBackgroundWeak",
+      selected: "colorBackgroundInfo",
+    }}
+    borderLeftColor={{
+      _: "colorBackground",
+      activeItem: "colorBackgroundWeak",
+      selected: "colorBorderPrimary",
+    }}
+    borderLeftStyle="borderStyleSolid"
+    borderLeftWidth="borderWidth20"
+    color={{
+      _: "colorTextStrongest",
+      disabled: "colorText",
+    }}
+    cursor="default"
+    fontSize="fontSize20"
+    fontWeight="fontWeightMedium"
+    px="d4"
+    py="d2"
+  />
+);
+export const ComboboxItem = forwardRef<
+  HTMLDivElement,
+  AriakitComboboxItemProps & {
+    children: React.ReactNode;
+  }
+>(({ children, render, store, ...props }, ref) => {
+  const selectedValue = store?.getState().selectedValue;
+
+  return (
+    <AriakitComboboxItem
+      aria-selected={selectedValue === props.value}
+      focusOnHover
+      ref={ref}
+      render={render || DefaultItem}
+      {...props}
+    >
+      {children}
+    </AriakitComboboxItem>
+  );
+});
+
+ComboboxItem.displayName = "ComboboxItem";

--- a/packages/components/src/components/Combobox/ComboboxPopover/ComboboxPopover.test.tsx
+++ b/packages/components/src/components/Combobox/ComboboxPopover/ComboboxPopover.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { useComboboxStore } from "@ariakit/react";
+import { ComboboxPopover } from "./ComboboxPopover";
+
+const ComboboxPopoverMock = () => {
+  const combobox = useComboboxStore({
+    open: true,
+  });
+
+  return (
+    <ComboboxPopover store={combobox}>
+      <div>Children content</div>
+    </ComboboxPopover>
+  );
+};
+
+describe("<ComboboxPopover />", () => {
+  it("renders popover with children", async () => {
+    render(<ComboboxPopoverMock />);
+
+    expect(await screen.findByText("Children content")).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/Combobox/ComboboxPopover/ComboboxPopover.tsx
+++ b/packages/components/src/components/Combobox/ComboboxPopover/ComboboxPopover.tsx
@@ -1,0 +1,39 @@
+import React, { forwardRef } from "react";
+import {
+  ComboboxPopover as AriakitComboboxPopover,
+  ComboboxPopoverProps as AriakitComboboxPopoverProps,
+} from "@ariakit/react";
+import { Box, BoxProps } from "../../../primitives/Box";
+
+export const ComboboxPopover = forwardRef<
+  HTMLDivElement,
+  AriakitComboboxPopoverProps & {
+    children: React.ReactNode;
+    zIndex?: BoxProps["zIndex"];
+  }
+>(({ children, zIndex = "zIndex50", ...props }, ref) => {
+  return (
+    <Box.div
+      as={AriakitComboboxPopover}
+      backgroundColor="bgPrimary"
+      borderRadius="borderRadius20"
+      boxShadow="shadowStrong"
+      display="flex"
+      flexDirection="column"
+      gutter={3}
+      maxHeight="250px"
+      overflow="auto"
+      overscrollBehavior="contain"
+      portal
+      ref={ref}
+      sameWidth
+      unmountOnHide
+      zIndex={zIndex}
+      {...props}
+    >
+      {children}
+    </Box.div>
+  );
+});
+
+ComboboxPopover.displayName = "ComboboxPopover";

--- a/packages/components/src/components/Combobox/ComboboxProvider/ComboboxProvider.tsx
+++ b/packages/components/src/components/Combobox/ComboboxProvider/ComboboxProvider.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import {
+  ComboboxProvider as AriakitComboboxProvider,
+  ComboboxProviderProps,
+} from "@ariakit/react";
+
+export const ComboboxProvider = (
+  props: ComboboxProviderProps,
+): React.ReactElement => {
+  return <AriakitComboboxProvider {...props} />;
+};

--- a/packages/components/src/components/Combobox/index.ts
+++ b/packages/components/src/components/Combobox/index.ts
@@ -1,0 +1,7 @@
+export { ComboboxPopover } from "./ComboboxPopover/ComboboxPopover";
+export { ComboboxItem } from "./ComboboxItem/ComboboxItem";
+export { ComboboxInput } from "./ComboboxInput/ComboboxInput";
+export { ComboboxProvider } from "./ComboboxProvider/ComboboxProvider";
+export type { ComboboxProps, ComboboxItemProps } from "./Combobox";
+export { Combobox } from "./Combobox";
+export { useComboboxStore } from "@ariakit/react";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -4,6 +4,7 @@ export * from "./components/Avatar";
 export * from "./components/Badge";
 export * from "./components/Button";
 export * from "./components/Callout";
+export * from "./components/Combobox";
 export * from "./components/ContentCard";
 export * from "./components/Checkbox";
 export * from "./components/Drawer";


### PR DESCRIPTION
### Storybook: https://632b1baf1257171b6a84f370-imqxqzvibp.chromatic.com/?path=/docs/components-combobox--docs

## Description of the change

Introduces new `Combobox` component:

- Combines a text input and a popover to allow users to filter from long lists of options
- Can be used as a standalone component or composed with other components such as `ComboboxInput`, `ComboboxPopover`, `ComboboxItem`, and `ComboboxProvider`
- Supports generic type for the options list
- Provides a prop `filterItem` prop to be used as the filter function when receiving a function. 

## Testing the change

- [ ] Write your testing instructions here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
