### PR TITLE
chore: update cache action to version 3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
       - name: Load Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn_cache_id
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-yarn
 
       - name: Node modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: node_modules_cache_id
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
       - name: Load Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn_cache_id
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -85,7 +85,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn
       - name: Node modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: node_modules_cache_id
         with:
           path: |
@@ -124,7 +124,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
       - name: Load Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn_cache_id
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -132,7 +132,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn
       - name: Node modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: node_modules_cache_id
         with:
           path: |
@@ -174,7 +174,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
       - name: Load Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn_cache_id
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -182,7 +182,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn
       - name: Node modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: node_modules_cache_id
         with:
           path: |


### PR DESCRIPTION
## Description of the change

- Our actions are breaking because this action is outdated. This PR updates to V3
